### PR TITLE
Build with LibSSH 0.6.3, too

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ check_function_exists(pthread_mutex_timedlock HAVE_PTHREAD_MUTEX_TIMEDLOCK)
 
 # dependencies - libssh
 if(ENABLE_SSH)
-    find_package(LibSSH 0.6.4 REQUIRED)
+    find_package(LibSSH 0.6.3 REQUIRED)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DNC_ENABLED_SSH ${LIBSSH_DEFINITIONS}")
     target_link_libraries(netconf2 ${LIBSSH_LIBRARIES} -L${SSH_LIBRARY} -lssh_threads -lcrypt)
     include_directories(${LIBSSH_INCLUDE_DIRS})

--- a/src/session_server_ssh.c
+++ b/src/session_server_ssh.c
@@ -1152,7 +1152,7 @@ nc_accept_ssh_session(struct nc_session *session, int sock, int timeout)
         return -1;
     }
     for (i = 0; i < opts->hostkey_count; ++i) {
-        if (ssh_bind_options_set(sbind, SSH_BIND_OPTIONS_HOSTKEY, opts->hostkeys[i]) != SSH_OK) {
+        if (ssh_bind_options_set(sbind, SSH_BIND_OPTIONS_RSAKEY, opts->hostkeys[i]) != SSH_OK) {
             ERR("Failed to set hostkey \"%s\" (%s).", opts->hostkeys[i], ssh_get_error(sbind));
             close(sock);
             ssh_bind_free(sbind);


### PR DESCRIPTION
...because that's what is available in Debian Jessie.

### -> Is this OK from your point of view?

Maybe there are some important bugfixes/features in that release which I'm not aware of. Changelog suggests new support for ECs, etc.