### PR TITLE
session BUGFIX capabilitys do not include ns if it is prefix of another

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -691,7 +691,7 @@ add_cpblt(struct ly_ctx *ctx, const char *capab, const char ***cpblts, int *size
             len = strlen(capab);
         }
         for (i = 0; i < *count; i++) {
-            if (!strncmp((*cpblts)[i], capab, len)) {
+            if (!strncmp((*cpblts)[i], capab, len) && ((*cpblts)[i][len] == '\0' || (*cpblts)[i][len] == '?')) {
                 /* already present, do not duplicate it */
                 return;
             }


### PR DESCRIPTION
Hi,
I found the namespace  is not sent to client in hello message, if it is prefix of another one. Such as "uri:ab" will not be added if "uri:abc" has already be added.