### PR TITLE
server session BUGFIX where crypt_r is not available

### DIFF
--- a/src/session_server_ssh.c
+++ b/src/session_server_ssh.c
@@ -28,6 +28,10 @@
 #include "session_server_ch.h"
 #include "libnetconf.h"
 
+#if !defined(HAVE_CRYPT_R)
+pthread_mutex_t crypt_lock = PTHREAD_MUTEX_INITIALIZER;
+#endif
+
 extern struct nc_server_opts server_opts;
 
 static char *
@@ -770,7 +774,9 @@ auth_password_compare_pwd(const char *pass_hash, const char *pass_clear)
     cdata.initialized = 0;
     new_pass_hash = crypt_r(pass_clear, pass_hash, &cdata);
 #else
+    pthread_mutex_lock(&crypt_lock);
     new_pass_hash = crypt(pass_clear, pass_hash);
+    pthread_mutex_unlock(&crypt_lock);
 #endif
     return strcmp(new_pass_hash, pass_hash);
 }

--- a/src/session_server_ssh.c
+++ b/src/session_server_ssh.c
@@ -751,7 +751,9 @@ static int
 auth_password_compare_pwd(const char *pass_hash, const char *pass_clear)
 {
     char *new_pass_hash;
+#if defined(HAVE_CRYPT_R)
     struct crypt_data cdata;
+#endif
 
     if (!pass_hash[0]) {
         if (!pass_clear[0]) {
@@ -764,8 +766,12 @@ auth_password_compare_pwd(const char *pass_hash, const char *pass_clear)
         }
     }
 
+#if defined(HAVE_CRYPT_R)
     cdata.initialized = 0;
     new_pass_hash = crypt_r(pass_clear, pass_hash, &cdata);
+#else
+    new_pass_hash = crypt(pass_clear, pass_hash);
+#endif
     return strcmp(new_pass_hash, pass_hash);
 }
 


### PR DESCRIPTION
Hi,

I encountered a portability issue with uclibc in OpenWrt. This patched fixed my problem and it has been tested on an older OpenWrt build (uclibc), on the latest Lede build (musl) and in docker (ubuntu 16.04).