### PR TITLE
server BUGFIX nc_ps_poll deadlock due to multi-thread conflict

### DIFF
--- a/src/session_p.h
+++ b/src/session_p.h
@@ -424,12 +424,14 @@ enum nc_ps_session_state {
     NC_PS_STATE_INVALID        /**< session is invalid and was already returned by another poll */
 };
 
+struct nc_ps_session {
+    struct nc_session *session;
+    enum nc_ps_session_state state;
+};
+
 /* ACCESS locked */
 struct nc_pollsession {
-    struct {
-        struct nc_session *session;
-        enum nc_ps_session_state state;
-    } *sessions;
+    struct nc_ps_session **sessions;
     uint16_t session_count;
     uint16_t last_event_session;
 

--- a/src/session_server_ssh.c
+++ b/src/session_server_ssh.c
@@ -1540,7 +1540,7 @@ nc_ps_accept_ssh_channel(struct nc_pollsession *ps, struct nc_session **session)
     }
 
     for (i = 0; i < ps->session_count; ++i) {
-        cur_session = ps->sessions[i].session;
+        cur_session = ps->sessions[i]->session;
         if ((cur_session->status == NC_STATUS_RUNNING) && (cur_session->ti_type == NC_TI_LIBSSH)
                 && cur_session->ti.libssh.next) {
             /* an SSH session with more channels */


### PR DESCRIPTION
Hi,
`nc_ps_poll` will enter a deadlock branch in the line 1412, this issue can be reproduced in following steps:
1, current session is in the last position of `ps->sessions`;
2, state of current session is been set to `NC_PS_STATE_BUSY`; 
3, current thread unlocks the ps lock in the line 1469;
4, another session is removed from  `ps->sessions` by another thread, and current session is copied to the removed position;
5, current thread set state of current session (in the old position, which is invalid now) to `NC_PS_STATE_NONE`;
6, the copied session state is always `NC_PS_STATE_BUSY`;
7, threads trap into deadlock when they handle this copied session.

By changing the `sessions` in the `struct nc_pollsession` to a pointer array, we can just move a pointer but not a struct when removing a session, then this issue is fixed.