### PR TITLE
MAINTENANCE removed redundant _POSIX_SOURCE flags

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -12,8 +12,7 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#define _GNU_SOURCE /* asprintf */
-#define _POSIX_SOUCE /* signals */
+#define _GNU_SOURCE /* asprintf, signals */
 #include <assert.h>
 #include <errno.h>
 #include <poll.h>

--- a/src/session_server.c
+++ b/src/session_server.c
@@ -11,7 +11,7 @@
  *
  *     https://opensource.org/licenses/BSD-3-Clause
  */
-#define _POSIX_SOUCE /* signals */
+#define _GNU_SOURCE /* signals, threads */
 
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/session_server_ssh.c
+++ b/src/session_server_ssh.c
@@ -13,7 +13,6 @@
  */
 
 #define _GNU_SOURCE
-#define _POSIX_SOURCE
 
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Hello,

when going through the source code, I found a typo in the `src/io.c` file. It caught my attention
because it seems that the library can be compiled OK even though the `_POSIX_SOURCE` is actually not defined, because the letter `R` is missing (`_POSIX_SOUCE`) from the statement.

After opening [the GNU C library "feature test macros" page](https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html) I found this description of the `_GNU_SOURCE` macro:

> If you define this macro, everything is included: ISO C89, ISO C99, **POSIX.1**, POSIX.2, BSD, SVID, X/Open, LFS, and GNU extensions. In the cases where POSIX.1 conflicts with BSD, the POSIX definitions take precedence.

Moreover, at the beginning of the page, there is the definition of the `_POSIX_SOURCE` macro:

> If you define this macro, then the functionality from the **POSIX.1** standard (IEEE Standard 1003.1) is available, as well as all of the ISO C facilities.

And finally, the very last sentence on the page states that:

> Likewise, if you define `_GNU_SOURCE`, then defining either `_POSIX_SOURCE` or `_POSIX_C_SOURCE` as well **has no effect**.

It is clear to me that it has no effect to `#define _POSIX_SOURCE` right the next line after `#define _GNU_SOURCE`, because according to the docs it has no effect, and therefore I propose to remove it alltogether.

**UPDATE**: I have also noticed the same situation inside the `src/session_server_ssh.c` source file. Therefore, I have updated this pull request to keep it consistent.

I have also noticed the same typo (`#define _POSIX_SOURCE` -> `#define _POSIX_SOUCE`) inside `src/session_server.c`. However, fixing the typo actually breaks the compilation, because some `pthread_*` symbols are suddenly missing...
Because at the top of `src/session_server_ssh.c` is `#define _GNU_SOURCE`, I believe that here, in `src/session_server.c` file should be `#define _GNU_SOURCE` as well.