### PR TITLE
Add optional authentication methods for ssh pubkey and interactive.

### DIFF
--- a/src/session_p.h
+++ b/src/session_p.h
@@ -169,6 +169,14 @@ struct nc_server_opts {
     int (*passwd_auth_clb)(const struct nc_session *session, const char *password, void *user_data);
     void *passwd_auth_data;
     void (*passwd_auth_data_free)(void *data);
+
+    int (*pubkey_auth_clb)(const struct nc_session *session, ssh_key key, void *user_data);
+    void *pubkey_auth_data;
+    void (*pubkey_auth_data_free)(void *data);
+
+    int (*interactive_auth_clb)(const struct nc_session *session, const char* password,void *user_data);
+    void *interactive_auth_data;
+    void (*interactive_auth_data_free)(void *data);
 #endif
 #ifdef NC_ENABLED_TLS
     int (*user_verify_clb)(const struct nc_session *session);

--- a/src/session_server.h
+++ b/src/session_server.h
@@ -22,6 +22,12 @@
 #   include <openssl/x509.h>
 #endif
 
+#ifdef NC_ENABLED_SSH
+#   include <libssh/libssh.h>
+#   include <libssh/callbacks.h>
+#   include <libssh/server.h>
+#endif
+
 #include "session.h"
 #include "netconf.h"
 
@@ -505,6 +511,29 @@ int nc_server_ssh_endpt_add_hostkey(const char *endpt_name, const char *name, in
  */
 void nc_server_ssh_set_passwd_auth_clb(int (*passwd_auth_clb)(const struct nc_session *session, const char *password,
                                                               void *user_data),
+                                       void *user_data, void (*free_user_data)(void *user_data));
+
+/**
+ * @brief Set the callback for SSH interactive authentication. If none is set, local system users are used.
+ *
+ * @param[in] interactive_auth_clb Callback that should authenticate the user.
+ *                            Zero return indicates success, non-zero an error.
+ * @param[in] user_data Optional arbitrary user data that will be passed to \p passwd_auth_clb.
+ * @param[in] free_user_data Optional callback that will be called during cleanup to free any \p user_data.
+ */
+void ncserver_ssh_set_interactive_auth_clb(int (*interactive_auth_clb)(const struct nc_session *session, const char *password,
+                                                              void *user_data),
+                                           void *user_data, void (*free_user_data)(void *user_data));
+
+/**
+ * @brief Set the callback for SSH public key authentication. If none is set, local system users are used.
+ *
+ * @param[in] pubkey_auth_clb Callback that should authenticate the user.
+ *                            Zero return indicates success, non-zero an error.
+ * @param[in] user_data Optional arbitrary user data that will be passed to \p passwd_auth_clb.
+ * @param[in] free_user_data Optional callback that will be called during cleanup to free any \p user_data.
+ */
+ void ncserver_ssh_set_pubkey_auth_clb(int (*pubkey_auth_clb)(const struct nc_session *session, ssh_key key, void *user_data),
                                        void *user_data, void (*free_user_data)(void *user_data));
 
 /**


### PR DESCRIPTION
Hey everyone,

We wanted to add optional callback functions for pubkey and interactive authentication for ssh. We noticed you had implemented it for password but we added functionality that will also authenticate users differently for pubkey and interactive if you register callbacks. We modeled them after the existing changes to password authentication. 

Please let us know your thoughts.

Thanks,
Brandon Hart