### PR TITLE
Fix segfault when crypt() returns NULL

### DIFF
--- a/src/session_server_ssh.c
+++ b/src/session_server_ssh.c
@@ -787,6 +787,11 @@ auth_password_compare_pwd(const char *pass_hash, const char *pass_clear)
     new_pass_hash = crypt(pass_clear, pass_hash);
     pthread_mutex_unlock(&crypt_lock);
 #endif
+
+    if (!new_pass_hash) {
+        return 1;
+    }
+
     return strcmp(new_pass_hash, pass_hash);
 }
 


### PR DESCRIPTION
`crypt()` and `crypt_r()` can return `NULL` when an error is encountered. For example, if a user has been locked using `usermod -L`, queries to the password database can return an encrypted password prefixed by `!`, and `crypt()` will return `NULL` because the password hash is malformed.

This change prevents `auth_password_compare_pwd()` from dereferencing a NULL pointer if `crypt()` or `crypt_r()` returns NULL due to an error. Instead, we now return nonzero in this case (i.e., authentication failed).