### PR TITLE
session: do not free rpc request external data

### DIFF
--- a/src/session_client.c
+++ b/src/session_client.c
@@ -1232,7 +1232,7 @@ parse_reply(struct ly_ctx *ctx, struct lyxml_elem *xml, struct nc_rpc *rpc, int 
     struct nc_reply_data *data_rpl;
     struct nc_reply *reply = NULL;
     struct nc_rpc_act_generic *rpc_gen;
-    int i;
+    int i, dofree = 1;
 
     if (!xml->child) {
         ERR("An empty <rpc-reply>.");
@@ -1300,6 +1300,7 @@ parse_reply(struct ly_ctx *ctx, struct lyxml_elem *xml, struct nc_rpc *rpc, int 
 
             if (rpc_gen->has_data) {
                 rpc_act = rpc_gen->content.data;
+                dofree = 0;
             } else {
                 rpc_act = lyd_parse_mem(ctx, rpc_gen->content.xml_str, LYD_XML, LYD_OPT_RPC | parseroptions, NULL);
                 if (!rpc_act) {
@@ -1373,7 +1374,8 @@ parse_reply(struct ly_ctx *ctx, struct lyxml_elem *xml, struct nc_rpc *rpc, int 
             /* <get>, <get-config> */
             data_rpl->data = data;
         }
-        lyd_free_withsiblings(rpc_act);
+        if (dofree)
+            lyd_free_withsiblings(rpc_act);
         if (!data_rpl->data) {
             ERR("Failed to parse <rpc-reply>.");
             free(data_rpl);


### PR DESCRIPTION
When making a generic rpc request:

```c
struct lyd_node *input;
struct nc_reply *reply
struct nc_rpc *rpc;
uint64_t msgid;

input= lyd_new_path(NULL, ctx, "/example:my-rpc/parameter", "value",
                    LYD_ANYDATA_CONSTSTRING, LYD_PATH_OPT_UPDATE);

rpc = nc_rpc_act_generic(input, NC_PARAMTYPE_CONST);
nc_send_rpc(session, rpc, 1000, &msgid);
nc_recv_reply(nc_session, rpc, msgid, 1000, &reply);  /* input is freed by parse_reply */

nc_reply_free(reply);
nc_rpc_free(rpc);
lyd_free_withsiblings(input);  /* double free here */
```

If the rpc request data was allocated outside of `parse_reply`, it should not be freed.

Only free it if it was allocated in `parse_reply()`.