### PR TITLE
Use nonzero lock timeout for transmitting messages

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -23,6 +23,7 @@
 #include <unistd.h>
 #include <signal.h>
 #include <time.h>
+#include <sys/param.h>
 
 #ifdef NC_ENABLED_TLS
 #   include <openssl/err.h>
@@ -1079,6 +1080,7 @@ nc_write_msg_io(struct nc_session *session, int io_timeout, int type, ...)
     arg.len = 0;
 
     /* SESSION IO LOCK */
+    io_timeout = MAX(io_timeout, NC_IO_LOCK_TIMEOUT);
     ret = nc_session_io_lock(session, io_timeout, __func__);
     if (ret < 0) {
         return NC_MSG_ERROR;

--- a/src/session_p.h
+++ b/src/session_p.h
@@ -296,6 +296,11 @@ struct nc_server_opts {
 #define NC_SESSION_FREE_LOCK_TIMEOUT 1000
 
 /**
+ * Timeout in msec for transmitting on a session.
+ */
+#define NC_IO_LOCK_TIMEOUT 1000
+
+/**
  * Timeout in msec for acquiring a lock of a pollsession structure.
  */
 #define NC_PS_LOCK_TIMEOUT 200


### PR DESCRIPTION
This commit adds a nonzero lock timeout for transmitting messages, which greatly improves the reliability of notifications.

The old timeout value of zero meant that if there was any lock contention whatsoever, notifications received from _sysrepo_ that needed to be sent along to clients would be dropped.

We added a nonzero lock timeout to allow the server to wait during the timeout for the lock contention to clear, so that it can transmit the notification.

The reliability improvement is dramatic. Whereas prior to this change, we saw notifications go missing around 3-5% of the time, now we are able to run our tests for more than 1000 iterations without missing a single notification.