### PR TITLE
Add the yang-library NETCONF capability

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -937,6 +937,13 @@ nc_server_get_cpblts_version(struct ly_ctx *ctx, LYS_VERSION version)
             sprintf(str, "%s?%s%s&module-set-id=%u", mod->ns, mod->rev_size ? "revision=" : "",
                     mod->rev_size ? mod->rev[0].date : "", ly_ctx_get_module_set_id(ctx));
             add_cpblt(ctx, str, &cpblts, &size, &count);
+
+            /* Add the yang-library NETCONF capability as defined in RFC 7950 5.6.4 */
+            sprintf(str, "urn:ietf:params:netconf:capability:yang-library:1.0?%s%s&module-set-id=%u",
+                    mod->rev_size ? "revision=" : "", mod->rev_size ? mod->rev[0].date : "",
+                    ly_ctx_get_module_set_id(ctx));
+            add_cpblt(ctx, str, &cpblts, &size, &count);
+
             continue;
         } else if (mod->type) {
             /* skip submodules */


### PR DESCRIPTION
This commit adds the yang-library NETCONF capability, which is required by
[RFC 7950 section 5.6.4](https://tools.ietf.org/html/rfc7950#section-5.6.4):

```
    The server also MUST advertise the following capability in the
    <hello> message (line breaks and whitespaces are used for formatting
    reasons only):

      urn:ietf:params:netconf:capability:yang-library:1.0?
        revision=<date>&module-set-id=<id>
```