### PR TITLE
Provide a mechanism to setup TLS cert chain

### DIFF
--- a/src/libnetconf.h
+++ b/src/libnetconf.h
@@ -394,7 +394,9 @@
  * So, after starting listening on an endpoint  you need to set the server
  * certificate (nc_server_tls_endpt_set_server_cert()). Its actual content
  * together with the matching private key will be loaded using a callback
- * from nc_server_tls_set_server_cert_clb().
+ * from nc_server_tls_set_server_cert_clb(). Additional certificates needed
+ * for the client to verify the server's certificate chain can be loaded using
+ * a callback from nc_server_tls_set_server_cert_chain_clb().
  *
  * To accept client certificates, they must first be considered trusted,
  * which you have three ways of achieving. You can add each of their Certificate Authority
@@ -428,6 +430,7 @@
  * - nc_server_tls_endpt_get_ctn()
  *
  * - nc_server_tls_set_server_cert_clb()
+ * - nc_server_tls_set_server_cert_chain_clb()
  * - nc_server_tls_set_trusted_cert_list_clb()
  *
  * FD

--- a/src/session_p.h
+++ b/src/session_p.h
@@ -186,6 +186,11 @@ struct nc_server_opts {
     void *server_cert_data;
     void (*server_cert_data_free)(void *data);
 
+    int (*server_cert_chain_clb)(const char *name, void *user_data, char ***cert_paths, int *cert_path_count,
+                                 char ***cert_data, int *cert_data_count);
+    void *server_cert_chain_data;
+    void (*server_cert_chain_data_free)(void *data);
+
     int (*trusted_cert_list_clb)(const char *name, void *user_data, char ***cert_paths, int *cert_path_count,
                                  char ***cert_data, int *cert_data_count);
     void *trusted_cert_list_data;

--- a/src/session_server.h
+++ b/src/session_server.h
@@ -664,6 +664,23 @@ void nc_server_tls_set_server_cert_clb(int (*cert_clb)(const char *name, void *u
                                        void *user_data, void (*free_user_data)(void *user_data));
 
 /**
+ * @brief Set the callback for retrieving server certificate chain
+ *
+ * @param[in] cert_chain_clb Callback that should return all the certificates of the chain. Zero return indicates success,
+ *                           non-zero an error. On success, \p cert_paths and \p cert_data are expected to be set or left
+ *                           NULL. Both will be (deeply) freed.
+ *                           - \p cert_paths expect an array of PEM files,
+ *                           - \p cert_path_count number of \p cert_paths array members,
+ *                           - \p cert_data expect an array of base-64 encoded ASN.1 DER cert data,
+ *                           - \p cert_data_count number of \p cert_data array members.
+ * @param[in] user_data Optional arbitrary user data that will be passed to \p cert_clb.
+ * @param[in] free_user_data Optional callback that will be called during cleanup to free any \p user_data.
+ */
+void nc_server_tls_set_server_cert_chain_clb(int (*cert_chain_clb)(const char *name, void *user_data, char ***cert_paths,
+                                                                   int *cert_path_count, char ***cert_data, int *cert_data_count),
+                                             void *user_data, void (*free_user_data)(void *user_data));
+
+/**
  * @brief Add a trusted certificate list. Can be both a CA or a client one. Can be
  *        safely used together with nc_server_tls_endpt_set_trusted_ca_paths().
  *

--- a/src/session_server_tls.c
+++ b/src/session_server_tls.c
@@ -986,6 +986,21 @@ nc_server_tls_set_server_cert_clb(int (*cert_clb)(const char *name, void *user_d
     server_opts.server_cert_data_free = free_user_data;
 }
 
+API void
+nc_server_tls_set_server_cert_chain_clb(int (*cert_chain_clb)(const char *name, void *user_data, char ***cert_paths,
+                                                              int *cert_path_count, char ***cert_data, int *cert_data_count),
+                                        void *user_data, void (*free_user_data)(void *user_data))
+{
+    if (!cert_chain_clb) {
+        ERRARG("cert_chain_clb");
+        return;
+    }
+
+    server_opts.server_cert_chain_clb = cert_chain_clb;
+    server_opts.server_cert_chain_data = user_data;
+    server_opts.server_cert_chain_data_free = free_user_data;
+}
+
 static int
 nc_server_tls_add_trusted_cert_list(const char *name, struct nc_server_tls_opts *opts)
 {
@@ -1705,6 +1720,78 @@ nc_tls_make_verify_key(void)
     pthread_key_create(&verify_key, NULL);
 }
 
+static X509*
+tls_load_cert(const char *cert_path, const char *cert_data)
+{
+    X509 *cert;
+
+    if (cert_path) {
+        cert = pem_to_cert(cert_path);
+    } else {
+        cert = base64der_to_cert(cert_data);
+    }
+
+    if (!cert) {
+        if (cert_path) {
+            ERR("Loading a trusted certificate (path \"%s\") failed (%s).", cert_path,
+                ERR_reason_error_string(ERR_get_error()));
+        } else {
+            ERR("Loading a trusted certificate (data \"%s\") failed (%s).", cert_data,
+                ERR_reason_error_string(ERR_get_error()));
+        }
+    }
+    return cert;
+}
+
+static int
+nc_tls_ctx_set_server_cert_chain(SSL_CTX *tls_ctx, const char *cert_name)
+{
+    char **cert_paths = NULL, **cert_data = NULL;
+    int cert_path_count = 0, cert_data_count = 0, ret = 0, i = 0;
+    X509 *cert = NULL;
+
+    if (!server_opts.server_cert_chain_clb) {
+        /* This is optional, so return OK */
+        return 0;
+    }
+
+    if (server_opts.server_cert_chain_clb(cert_name, server_opts.server_cert_chain_data, &cert_paths,
+                                          &cert_path_count, &cert_data, &cert_data_count)) {
+        ERR("Server certificate chain callback failed.");
+        return -1;
+    }
+
+    for (i = 0; i < cert_path_count; ++i) {
+        cert = tls_load_cert(cert_paths[i], NULL);
+        if (!cert || SSL_CTX_add_extra_chain_cert(tls_ctx, cert) != 1) {
+            ERR("Loading the server certificate chain failed (%s).", ERR_reason_error_string(ERR_get_error()));
+            ret = -1;
+            goto cleanup;
+        }
+    }
+
+    for (i = 0; i < cert_data_count; ++i) {
+        cert = tls_load_cert(NULL, cert_data[i]);
+        if (!cert || SSL_CTX_add_extra_chain_cert(tls_ctx, cert) != 1) {
+            ERR("Loading the server certificate chain failed (%s).", ERR_reason_error_string(ERR_get_error()));
+            ret = -1;
+            goto cleanup;
+        }
+    }
+cleanup:
+    for (i = 0; i < cert_path_count; ++i) {
+        free(cert_paths[i]);
+    }
+    free(cert_paths);
+    for (i = 0; i < cert_data_count; ++i) {
+        free(cert_data[i]);
+    }
+    free(cert_data);
+    /* cert is owned by the SSL_CTX */
+
+    return ret;
+}
+
 static int
 nc_tls_ctx_set_server_cert_key(SSL_CTX *tls_ctx, const char *cert_name)
 {
@@ -1759,6 +1846,8 @@ nc_tls_ctx_set_server_cert_key(SSL_CTX *tls_ctx, const char *cert_name)
         }
     }
 
+    ret = nc_tls_ctx_set_server_cert_chain(tls_ctx, cert_name);
+
 cleanup:
     X509_free(cert);
     EVP_PKEY_free(pkey);
@@ -1772,22 +1861,8 @@ cleanup:
 static void
 tls_store_add_trusted_cert(X509_STORE *cert_store, const char *cert_path, const char *cert_data)
 {
-    X509 *cert;
-
-    if (cert_path) {
-        cert = pem_to_cert(cert_path);
-    } else {
-        cert = base64der_to_cert(cert_data);
-    }
-
+    X509 *cert = tls_load_cert(cert_path, cert_data);
     if (!cert) {
-        if (cert_path) {
-            ERR("Loading a trusted certificate (path \"%s\") failed (%s).", cert_path,
-                ERR_reason_error_string(ERR_get_error()));
-        } else {
-            ERR("Loading a trusted certificate (data \"%s\") failed (%s).", cert_data,
-                ERR_reason_error_string(ERR_get_error()));
-        }
         return;
     }
 


### PR DESCRIPTION
This commit from @jwwilcox, together with a corresponding commit to _netopeer2_, fixes the TLS connection scenario in which the server's certificate has been signed by an intermediate CA, but the client only has the root CA available locally. In this case, the client will reject the connection attempt, because it does not know about the intermediate CA.

The changes here use the new _netopeer2_ callback (which supplies the intermediate certificate(s)) to call `SSL_CTX_add_extra_chain_cert()`, which allows the server's TLS context to automatically provide the intermediate certificate(s) to the client.

This scenario is demonstrated in the integration test `test_tls_client_missing_server_intermediate()` in [ADTRAN:netopeer2-integration-tests](https://github.com/ADTRAN/netopeer2-integration-tests/blob/master/tests/test_tls.py#L73). The changes here, together with the corresponding commit in _netopeer2_, will allow [the currently failing test case](https://travis-ci.org/ADTRAN/netopeer2-integration-tests/jobs/420293391#L7434) to pass.