### PR TITLE
Two small TLS bug fixes

### DIFF
--- a/src/session_server_tls.c
+++ b/src/session_server_tls.c
@@ -513,7 +513,7 @@ nc_tlsclb_verify(int preverify_ok, X509_STORE_CTX *x509_ctx)
     /* get the last certificate, that is the peer (client) certificate */
     if (!session->opts.server.client_cert) {
         cert_stack = X509_STORE_CTX_get1_chain(x509_ctx);
-        session->opts.server.client_cert = sk_X509_value(cert_stack, sk_X509_num(cert_stack) - 1);
+        session->opts.server.client_cert = sk_X509_value(cert_stack, 0);
         X509_up_ref(session->opts.server.client_cert);
         sk_X509_pop_free(cert_stack, X509_free);
     }
@@ -1406,7 +1406,7 @@ nc_server_tls_add_ctn(uint32_t id, const char *fingerprint, NC_TLS_CTN_MAPTYPE m
         new->next = opts->ctn;
         opts->ctn = new;
     } else {
-        for (ctn = opts->ctn; ctn->next && ctn->next->id < id; ctn = ctn->next);
+        for (ctn = opts->ctn; ctn->next && ctn->next->id <= id; ctn = ctn->next);
         if (ctn->id == id) {
             /* it exists already */
             new = ctn;


### PR DESCRIPTION
This commit from @jwwilcox fixes two TLS bugs.

The first is that in OpenSSL 1.1.0 and later, the client's certificate is actually the first in the stack, not the last. (The corresponding function for previous versions of OpenSSL remains unchanged.)

The second change fixes an off-by-one error in the loop searching for a matching cert-to-name mapping. (The bug is evident when there is more than one cert-to-name mapping present.)

These two fixes will allow the following three failing test cases in [ADTRAN:netopeer2-integration-tests](https://github.com/ADTRAN/netopeer2-integration-tests/blob/master/tests/test_tls.py#L175) to pass:
* `test_tls_only_client_leaf_trusted_and_fingerprint_of_client_CA()`
* `test_tls_only_client_leaf_trusted_and_fingerprint_of_client_leaf()`
* `test_tls_fingerprint_cascade()`

(The Travis CI results are available [here](https://travis-ci.org/ADTRAN/netopeer2-integration-tests/builds/421746115#L7435).)