### PR TITLE
Silence warnings by forward-declaring libyang's structs

### DIFF
--- a/src/messages_server.h
+++ b/src/messages_server.h
@@ -20,6 +20,9 @@
 #include "netconf.h"
 #include "session.h"
 
+struct lyd_node;
+struct lyxml_elem;
+
 /**
  * @defgroup server_msg Server Messages
  * @ingroup server


### PR DESCRIPTION
Without this patch, I'm getting plenty of these when building
Netopeer2-server:

```
  In file included from /opt/nc/include/nc_server.h:27,
                   from Netopeer2/server/ietf_system.c:21:
  /opt/nc/include/libnetconf2/messages_server.h:99:53: warning: ‘struct lyd_node’ declared inside parameter list will not be visible outside of this definition or declaration
   struct nc_server_reply *nc_server_reply_data(struct lyd_node *data, NC_WD_MODE wd, NC_PARAMTYPE paramtype);
                                                       ^~~~~~~~
  /opt/nc/include/libnetconf2/messages_server.h:288:63: warning: ‘struct lyxml_elem’ declared inside parameter list will not be visible outside of this definition or declaration
   int nc_err_add_info_other(struct nc_server_error *err, struct lyxml_elem *other);
                                                                 ^~~~~~~~~~
  /opt/nc/include/libnetconf2/messages_server.h:315:52: warning: ‘struct lyd_node’ declared inside parameter list will not be visible outside of this definition or declaration
   struct nc_server_notif *nc_server_notif_new(struct lyd_node *event, char *eventtime, NC_PARAMTYPE paramtype);
                                                      ^~~~~~~~
```