### PR TITLE
client session: fix lock on wrong mutex

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -344,7 +344,7 @@ nc_session_io_lock(struct nc_session *session, int timeout, const char *func)
     } else if (!timeout) {
         ret = pthread_mutex_trylock(session->io_lock);
     } else { /* timeout == -1 */
-        ret = pthread_mutex_lock(session->opts.server.rpc_lock);
+        ret = pthread_mutex_lock(session->io_lock);
     }
 
     if (ret) {


### PR DESCRIPTION
This fixes a segfault when running `nc_connect_ssh_channel()`.

```
Program terminated with signal SIGSEGV, Segmentation fault.
 #0  __GI___pthread_mutex_lock (mutex=0x0) at ../nptl/pthread_mutex_lock.c:65
 #1  0x00007f0b38c0edf8 in nc_session_io_lock (session=0x561dc93a73b0, timeout=-1,
     func=0x7f0b38c36d60 <__func__.24731> "nc_connect_ssh_channel")
     at libnetconf2/src/session.c:347
 #2  0x00007f0b38c25f23 in nc_connect_ssh_channel (session=0x561dc8cc3200, ctx=0x561dc8cc7130)
     at libnetconf2/src/session_client_ssh.c:1753
```

Fixes: 131120aa5693 ("CHANGE allow concurrent notifications and RPCs")