### PR TITLE
add support for unix socket transport

### DIFF
--- a/python/session.c
+++ b/python/session.c
@@ -324,9 +324,14 @@ newChannel(PyObject *self)
 static PyObject *
 ncSessionStr(ncSessionObject *self)
 {
-    return PyUnicode_FromFormat("NETCONF Session %u to %s:%u (%lu references)", nc_session_get_id(self->session),
-                                nc_session_get_host(self->session), nc_session_get_port(self->session),
-                                ((PyObject*)(self))->ob_refcnt);
+    const char *host = nc_session_get_host(self->session);
+    if (host)
+        return PyUnicode_FromFormat("NETCONF Session %u to %s:%u (%lu references)", nc_session_get_id(self->session),
+                                    nc_session_get_host(self->session), nc_session_get_port(self->session),
+                                    ((PyObject*)(self))->ob_refcnt);
+    else
+        return PyUnicode_FromFormat("NETCONF Session %u to %s (%lu references)", nc_session_get_id(self->session),
+                                    nc_session_get_path(self->session), ((PyObject*)(self))->ob_refcnt);
 }
 
 /*
@@ -362,6 +367,12 @@ static PyObject *
 ncSessionGetHost(ncSessionObject *self, void *closure)
 {
     return PyUnicode_FromString(nc_session_get_host(self->session));
+}
+
+static PyObject *
+ncSessionGetPath(ncSessionObject *self, void *closure)
+{
+    return PyUnicode_FromString(nc_session_get_path(self->session));
 }
 
 static PyObject *

--- a/src/libnetconf.h
+++ b/src/libnetconf.h
@@ -335,7 +335,9 @@
  *
  * To be able to accept any connections, endpoints must first be added
  * with nc_server_add_endpt() and configured with nc_server_endpt_set_address()
- * and nc_server_endpt_set_port().
+ * and nc_server_endpt_set_port(). For unix sockets, nc_server_endpt_set_perms()
+ * is available to set the unix socket file permissions, and nc_server_endpt_set_port()
+ * is invalid.
  *
  * Functions List
  * --------------
@@ -351,6 +353,7 @@
  * - nc_server_del_endpt()
  * - nc_server_endpt_set_address()
  * - nc_server_endpt_set_port()
+ * - nc_server_endpt_set_perms()
  *
  *
  * SSH

--- a/src/session.c
+++ b/src/session.c
@@ -506,6 +506,19 @@ nc_session_get_host(const struct nc_session *session)
     return session->host;
 }
 
+API const char *
+nc_session_get_path(const struct nc_session *session)
+{
+    if (!session) {
+        ERRARG("session");
+        return NULL;
+    }
+    if (session->ti_type != NC_TI_UNIX)
+        return NULL;
+
+    return session->path;
+}
+
 API uint16_t
 nc_session_get_port(const struct nc_session *session)
 {
@@ -698,6 +711,12 @@ nc_session_free(struct nc_session *session, void (*data_free)(void *))
         (void)siter;
         break;
 
+    case NC_TI_UNIX:
+        sock = session->ti.unixsock.sock;
+        (void)connected;
+        (void)siter;
+        break;
+
 #ifdef NC_ENABLED_SSH
     case NC_TI_LIBSSH:
         if (connected) {
@@ -799,6 +818,7 @@ nc_session_free(struct nc_session *session, void (*data_free)(void *))
 
     lydict_remove(session->ctx, session->username);
     lydict_remove(session->ctx, session->host);
+    lydict_remove(session->ctx, session->path);
 
     /* final cleanup */
     if ((session->side == NC_SERVER) && session->opts.server.rpc_lock) {

--- a/src/session.h
+++ b/src/session.h
@@ -65,6 +65,7 @@ typedef enum {
     NC_TI_NONE = 0,   /**< none - session is not connected yet */
     NC_TI_FD,         /**< file descriptors - use standard input/output, transport protocol is implemented
                            outside the current application */
+    NC_TI_UNIX,       /**< unix socket */
 #ifdef NC_ENABLED_SSH
     NC_TI_LIBSSH,     /**< libssh - use libssh library, only for NETCONF over SSH transport */
 #endif
@@ -176,6 +177,14 @@ const char *nc_session_get_host(const struct nc_session *session);
  * @return Session port.
  */
 uint16_t nc_session_get_port(const struct nc_session *session);
+
+/**
+ * @brief Get session path (unix socket only).
+ *
+ * @param[in] session Session to get the information from.
+ * @return Session unix socket path.
+ */
+const char *nc_session_get_path(const struct nc_session *session);
 
 /**
  * @brief Get session context.

--- a/src/session_client.h
+++ b/src/session_client.h
@@ -145,6 +145,25 @@ void nc_client_destroy(void);
  */
 struct nc_session *nc_connect_inout(int fdin, int fdout, struct ly_ctx *ctx);
 
+/**
+ * @brief Connect to the NETCONF server via unix socket.
+ *
+ * Connect to netconf server via an unix socket. Function do not cover authentication
+ * or any other manipulation with the transport layer, it only establish NETCONF session
+ * by sending and processing NETCONF \<hello\> messages.
+ *
+ * @param[in] address Path to the unix socket.
+ * @param[in] ctx Optional parameter. If set, provides strict YANG context for the session
+ *                (ignoring what is actually supported by the server side). If not set,
+ *                YANG context is created for the session using \<get-schema\> (if supported
+ *                by the server side) or/and by searching for YANG schemas in the searchpath
+ *                (see nc_client_schema_searchpath()). In every case except not providing context
+ *                to connect to a server supporting \<get-schema\> it is possible that
+ *                the session context will not include all the models supported by the server.
+ * @return Created NETCONF session object or NULL in case of error.
+ */
+struct nc_session *nc_connect_unix(const char *address, struct ly_ctx *ctx);
+
 /**@} Client Session */
 
 #ifdef NC_ENABLED_SSH

--- a/src/session_server.h
+++ b/src/session_server.h
@@ -399,6 +399,20 @@ int nc_server_endpt_set_address(const char *endpt_name, const char *address);
  */
 int nc_server_endpt_set_port(const char *endpt_name, uint16_t port);
 
+/**
+ * @brief Change endpoint permissions.
+ *
+ * This is only valid on unix transport endpoint.
+ * On error the previous listening socket (if any) is left untouched.
+ *
+ * @param[in] endpt_name Existing endpoint name.
+ * @param[in] mode New mode, -1 to use default.
+ * @param[in] uid New uid, -1 to use default.
+ * @param[in] gid New gid, -1 to use default.
+ * @return 0 on success, -1 on error.
+ */
+int nc_server_endpt_set_perms(const char *endpt_name, mode_t mode, uid_t uid, gid_t gid);
+
 /**@} Server */
 
 /**


### PR DESCRIPTION
In addition to SSH and TLS transport, add the support for UNIX
socket. Despite it's not in NETCONF standard, using a UNIX socket has
several advantages:

- no need of password, keys, or certificate. The connection is allowed
  for a local user authenticated on the system, and having the proper
  permissions to connect to the netopeer socket.

- the connection to netopeer is possible even if the firewall is
  enabled. This is an advantage when configuring a firewall equipment
  through netconf.

- the connection to netopeer is possible from another netns.

Signed-off-by: Olivier Matz <olivier.matz@6wind.com>