### PR TITLE
remove duplicated setsockopts for keepalive

### DIFF
--- a/src/session_server.c
+++ b/src/session_server.c
@@ -389,34 +389,6 @@ nc_sock_accept_binds(struct nc_bind *binds, uint16_t bind_count, int timeout, ch
         return -1;
     }
 
-    if (saddr.ss_family == AF_INET || saddr.ss_family == AF_INET6) {
-        /* enable keep-alive */
-#ifdef TCP_KEEPIDLE
-        flags = 1;
-        if (setsockopt(ret, IPPROTO_TCP, TCP_KEEPIDLE, &flags, sizeof flags) == -1) {
-            ERR("Setsockopt failed (%s).", strerror(errno));
-            close(ret);
-            return -1;
-        }
-#endif
-#ifdef TCP_KEEPINTVL
-        flags = 5;
-        if (setsockopt(ret, IPPROTO_TCP, TCP_KEEPINTVL, &flags, sizeof flags) == -1) {
-            ERR("Setsockopt failed (%s).", strerror(errno));
-            close(ret);
-            return -1;
-        }
-#endif
-#ifdef TCP_KEEPCNT
-        flags = 10;
-        if (setsockopt(ret, IPPROTO_TCP, TCP_KEEPCNT, &flags, sizeof flags) == -1) {
-            ERR("Setsockopt failed (%s).", strerror(errno));
-            close(ret);
-            return -1;
-        }
-#endif
-    }
-
     if (idx) {
         *idx = i;
     }


### PR DESCRIPTION
When rebasing commit ac7fa2fb48a3 ("add support for unix socket
transport"), a conflict with commit be52dc29b169 ("session CHANGE
enable keep-alive for both server and client TCP sessions") was not
properly managed. This resulted in duplicated code in
nc_sock_accept_binds() to set the tcp keepalive socket options.

Remove the duplicated code from nc_sock_accept_binds(), since it is
already done in nc_sock_enable_keepalive().

Fixes: ac7fa2fb48a3 ("add support for unix socket transport")
Signed-off-by: Olivier Matz <olivier.matz@6wind.com>