### PR TITLE
Race condition in nc_ps_lock

### DIFF
--- a/src/session_server.c
+++ b/src/session_server.c
@@ -898,7 +898,7 @@ nc_ps_lock(struct nc_pollsession *ps, uint8_t *id, const char *func)
              * and this thread had already timed out. When this thread is scheduled, it returns timed out error
              * but when actually this thread was ready for condition.
              */
-            if (ps->queue[ps->queue_begin] == *id) {
+            if ((ETIMEDOUT == ret) && (ps->queue[ps->queue_begin] == *id)) {
                 break;
             }
             

--- a/src/session_server.c
+++ b/src/session_server.c
@@ -898,7 +898,7 @@ nc_ps_lock(struct nc_pollsession *ps, uint8_t *id, const char *func)
              * and this thread had already timed out. When this thread is scheduled, it returns timed out error
              * but when actually this thread was ready for condition.
              */
-            if (ps->queue[ps->queue_begin] != *id) {
+            if (ps->queue[ps->queue_begin] == *id) {
                 break;
             }
             


### PR DESCRIPTION
On our platform, all netconf server threads got stuck at this thing.

The current thread was ready to grab the lock because another thread had released the lock. But when the current thread was scheduled, pthread_cond_timedwait() returned S_errno_ETIMEDOUT error. As such we removed this from the queue. (And more threads waiting for the lock so queue len was not modified to 0).

So nobody is left to broadcast the condition and all the threads get stuck on waiting for the broadcast signal. They timeout and then wait again and this goes on.