### PR TITLE
fix and testcase for empty deviation parameter

### DIFF
--- a/schemas/module-a-dv.yang
+++ b/schemas/module-a-dv.yang
@@ -1,0 +1,16 @@
+module module-a-dv {
+
+    namespace "urn:jmu:params:xml:ns:yang:module-a-dv";
+    prefix dv;
+    
+    import module-a {
+        prefix a;
+    }
+    
+    description 
+        "Contains some deviations to module-a";
+
+    deviation "/a:top/a:hidden" {
+        deviate not-supported;
+    }
+}

--- a/schemas/module-a-dv2.yang
+++ b/schemas/module-a-dv2.yang
@@ -1,0 +1,21 @@
+module module-a-dv2 {
+
+    namespace "urn:jmu:params:xml:ns:yang:module-a-dv2";
+    prefix dv2;
+    
+    import module-a {
+        prefix a;
+    }
+    
+    description 
+        "Contains some deviations to module-a";
+
+    deviation "/a:top/a:type" {   
+        deviate add {
+            default "admin";
+            must "count(.) = 1";   
+        }        
+    }   
+    
+}
+

--- a/schemas/module-a.yang
+++ b/schemas/module-a.yang
@@ -1,0 +1,23 @@
+module module-a {
+
+    namespace "urn:jmu:params:xml:ns:yang:module-a";
+    prefix a;
+    
+    description "This is a simple user module";
+    
+    container top {
+    
+        leaf name {
+            type string;
+        }    
+    
+        leaf type {
+            type string;
+        }    
+        
+        leaf hidden {
+            type boolean;
+        }
+        
+    }
+}

--- a/src/session.c
+++ b/src/session.c
@@ -1032,6 +1032,7 @@ nc_server_get_cpblts_version(struct ly_ctx *ctx, LYS_VERSION version)
             strcat(str, "&deviations=");
             str_len += 12;
             dev_count = 0;
+            v = 0;
             while ((devmod = ly_ctx_get_module_iter(ctx, &v))) {
                 if (devmod == mod) {
                     continue;

--- a/tests/test_server_thread.c
+++ b/tests/test_server_thread.c
@@ -543,6 +543,9 @@ tls_client_thread(void *arg)
     session = nc_connect_tls("127.0.0.1", 6501, NULL);
     nc_assert(session);
 
+    /* verify some capabilities */
+    nc_assert( nc_session_cpblt(session, "urn:jmu:params:xml:ns:yang:module-a?module=module-a&deviations=module-a-dv,module-a-dv2") );
+
     nc_session_free(session, NULL);
 
     fprintf(stdout, "TLS client finished.\n");
@@ -657,6 +660,12 @@ main(void)
     ctx = ly_ctx_new(TESTS_DIR"/../schemas", 0);
     nc_assert(ctx);
     ly_ctx_load_module(ctx, "ietf-netconf", NULL);
+
+    /* load some application models with deviations */
+    nc_assert( ly_ctx_load_module(ctx, "module-a", NULL) );
+    nc_assert( ly_ctx_load_module(ctx, "module-a-dv", NULL) );
+    nc_assert( ly_ctx_load_module(ctx, "module-a-dv2", NULL) );
+
     nc_server_init(ctx);
 
     pthread_barrier_init(&barrier, NULL, thread_count);


### PR DESCRIPTION
In our tests, the \<capability\> element in \<hello\> message sporadically contained an empty deviations parameter ("&deviations="). The issue could be reproduced by a test case (test_server_thread.c).
We see the root cause in the missing initialization of v in in nc_server_get_cpblts_version().

Please have a look,
Frank