### PR TITLE
libssh: Fix the replace order to derive libssh path

### DIFF
--- a/CMakeModules/FindLibSSH.cmake
+++ b/CMakeModules/FindLibSSH.cmake
@@ -70,11 +70,11 @@ else (LIBSSH_LIBRARY_DIR AND LIBSSH_INCLUDE_DIRS)
   )
 
   if (SSH_FOUND)
-    string(REPLACE "ssh.so" ""
+    string(REPLACE "libssh.so" ""
       LIBSSH_LIBRARY_DIR
       ${SSH_LIBRARY}
     )
-    string(REPLACE "libssh.so" ""
+    string(REPLACE "ssh.so" ""
       LIBSSH_LIBRARY_DIR
       ${LIBSSH_LIBRARY_DIR}
     )


### PR DESCRIPTION
In order to derive the library path to include for libssh from the .so
file path, fix the replace order, otherwise you end up with an extra
"/lib" in the path and the build will not be able to find the libssh.