### PR TITLE
Trivial: delete unnecessary assignment in nc_err_set_msg().

### DIFF
--- a/src/messages_server.c
+++ b/src/messages_server.c
@@ -630,8 +630,6 @@ nc_err_set_msg(struct nc_server_error *err, const char *error_message, const cha
     }
     if (lang) {
         err->message_lang = lydict_insert(server_opts.ctx, lang, 0);
-    } else {
-        lang = NULL;
     }
 
     return 0;


### PR DESCRIPTION
cppcheck noticed, toward the end of nc_err_set_msg() in src/messages_server.c, that there is an unnecessary "lang = NULL;" assignment in an "else" branch where it is known that lang is NULL.  This patch deletes that unnecessary assignment.

I am having a cmake problem right now (something is trying to link with -lpthreads instead of -lpthread, even though this does not appear to be mentioned in the source tree), so I have not even built this, but the patch is quite trivial, so I am submitting it anyway.  However, if you prefer, please feel free to tell me to wait until I have at least compiled it.

This may be the only legitimate complaint that "cppcheck --enable=warning ." found.  Giving it "--enable=all" of course produces more output, which I am examining.

Thanks in advance for considering this trivial patch.