### PR TITLE
Eliminte two trivial redundancies, which the compiler already optimizes out

### DIFF
--- a/src/messages_server.c
+++ b/src/messages_server.c
@@ -630,8 +630,6 @@ nc_err_set_msg(struct nc_server_error *err, const char *error_message, const cha
     }
     if (lang) {
         err->message_lang = lydict_insert(server_opts.ctx, lang, 0);
-    } else {
-        lang = NULL;
     }
 
     return 0;

--- a/src/session_server_tls.c
+++ b/src/session_server_tls.c
@@ -1625,7 +1625,7 @@ nc_server_tls_get_ctn(uint32_t *id, char **fingerprint, NC_TLS_CTN_MAPTYPE *map_
         if (map_type && !(*map_type) && ctn->map_type) {
             *map_type = ctn->map_type;
         }
-        if (name && !(*name) && ctn->name && ctn->name) {
+        if (name && !(*name) && ctn->name) {
             *name = strdup(ctn->name);
         }
 


### PR DESCRIPTION
This pull request eliminates the following two trivial redundancies, both found by cppcheck.

src/messages.c: nc_err_set_msg() assigned the parameter lang to NULL when it already was guaranteed to have that value.  Also, the parameter is never used after that point anyhow.

src/session_server_tls.c: nc_server_tls_get_ctn() had duplicate "&&" clauses ("[...] ctn->name && ctn->name")

These deletions result in unchanged .o files on x86_64 if I build with "-O2" and add a couple of blank lines to messages.c to keep the line numbers the same.

Thanks in advance for considering this patch.
