### PR TITLE
Split a few "assert(a && b)" statements for more precise diagnostics.

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -336,7 +336,8 @@ nc_read_msg_io(struct nc_session *session, int io_timeout, struct lyxml_elem **d
     struct timespec ts_act_timeout;
     struct nc_server_reply *reply;
 
-    assert(session && data);
+    assert(session);
+    assert(data);
     *data = NULL;
 
     if ((session->status != NC_STATUS_RUNNING) && (session->status != NC_STATUS_STARTING)) {

--- a/src/session.c
+++ b/src/session.c
@@ -100,7 +100,8 @@ nc_difftimespec(const struct timespec *ts1, const struct timespec *ts2)
 void
 nc_addtimespec(struct timespec *ts, uint32_t msec)
 {
-    assert((ts->tv_nsec >= 0) && (ts->tv_nsec < 1000000000L));
+    assert(ts->tv_nsec >= 0);
+    assert(ts->tv_nsec < 1000000000L);
 
     ts->tv_sec += msec / 1000;
     ts->tv_nsec += (msec % 1000) * 1000000L;
@@ -113,7 +114,8 @@ nc_addtimespec(struct timespec *ts, uint32_t msec)
         ts->tv_nsec += 1000000000L;
     }
 
-    assert((ts->tv_nsec >= 0) && (ts->tv_nsec < 1000000000L));
+    assert(ts->tv_nsec >= 0);
+    assert(ts->tv_nsec < 1000000000L);
 }
 
 int

--- a/src/session_client.c
+++ b/src/session_client.c
@@ -964,7 +964,8 @@ nc_ctx_check_and_fill(struct nc_session *session)
     char *revision;
     struct schema_info *server_modules = NULL, *sm = NULL;
 
-    assert(session->opts.client.cpblts && session->ctx);
+    assert(session->opts.client.cpblts);
+    assert(session->ctx);
 
     /* store the original user's callback, we will be switching between local search, get-schema and user callback */
     old_clb = ly_ctx_get_module_imp_clb(session->ctx, &old_data);


### PR DESCRIPTION
Thanks for merging in my previous pull request.  I was thinking of merging this into that pull request if I needed to increase the number of lines covered by test cases by somewhat legitimate means, but, I figured it is easier to evaluate separate pull requests.  Now that I have made the change, I feel like I ought to go ahead and submit it.

I should also warn that I have only compiled the code, not run it.  I tried configuring with cmake with  -DENABLE_BUILD_TESTS=ON, but I did not immediately notice a resultant test program to run.  So, I hope it is OK that I am going forward with this making a pull request for this trivial change.

This change splits "assert(a && b)" statements into separate "assert(a)" and "assert(b)"
statements for more precise diagnostics in the three functions which
"egrep -r 'assert.*&&'" found:

src/io.c: nc_read_msg_io()
src/session.c: nc_difftimespec()
src/session_client.c: nc_ctx_check_and_fill()

Here is a slightly customized boilerplate argument for why I encourage splitting such assert statements (which I only include in the pull request, not the commit message, which is much smaller), but I should also add that keeping developers happy may have a bigger impact on development trajectory, so if you or other just prefer conjunctions in assert statements, I understand.  Anyhow, here goes.

1. Assertion failures are often sporadic, and users who report them may
   not be in a position to efficiently narrow them down further, so it
   is important to get as much precision from each assertion failure as
   possible.  This may be particularly true for the nc_difftimespec() change
   in src/session.c, as it is based on math on subsecond times.

2. It is a more efficient use of developers time when a bug report
   arrives if the problem has been narrowed down that much more.  A
   new bug report may initially attract more interest, so, if the
   problem has been narrowed down that much more, it may increase the
   chance that developers may invest the time to try to resolve the
   problem, and also reduce unnecessary traffic on the developer mailing
   list about possible causes of the bug that separating the assertion
   was able to rule out.
   
3. When using a debugger to step over an assertion failure in the
   first part of the statement, the second part is still tested.

4. Providing separate likelihood hints to the compiler in the form
   of separate assert statements does not require the compiler to
   be quite as smart to recognize that it should optimize both branches,
   although I do not know if that makes a difference for any compiler
   commonly used to compile libnetconf2 (that is, I suspect that they are
   all smart enough to realize is that "a && b" is likely true, then "a"
   is likely true and "b" is likely true), and, surprisingly, it appears to me
   that glibc's assert() does not include a compiler branch hint (although,
   for example, BUG_ON() in the Linux kernel did for x86_64 when I
   last checked).

5. Separated assertions can be more readable, sometimes eliminating
   parentheses, often making references to the same values line up
   on the same columns, which can make range checks more obvious,
   and sometimes changing multi-line conditions to separate single
   line conditions, which can be recognized separately.

   Consider, for example, how columnization in this makes this range
   check more recongizable and makes it easier to recognize in a glance
   that it is a bounds check and what the bounds are:

                assert(reg.vstride >= 0 && reg.vstride < ARRAY_SIZE(vstride_for_reg));
                        ... vs. ...

                assert(reg.vstride >= 0);
                assert(reg.vstride < ARRAY_SIZE(vstride_for_reg));

   A possible counter-argument to this might be that, in a sequence of
   assertions, it can be informative to group related assertions together.
   That can be true, but it is possible to get this grouping other means,
   such as by using blank lines to separate expressly such grouping, and
   still have the more informative assertion failure messages from separate
   assertion calls.

Thank you for considering this patch submission.