### PR TITLE
Add support for musl libc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,7 @@ target_link_libraries(netconf2 ${CMAKE_THREAD_LIBS_INIT})
 set(CMAKE_REQUIRED_LIBRARIES pthread)
 check_include_file(stdatomic.h HAVE_STDATOMIC)
 check_function_exists(pthread_mutex_timedlock HAVE_PTHREAD_MUTEX_TIMEDLOCK)
+check_function_exists(pthread_rwlockattr_setkind_np HAVE_PTHREAD_RWLOCKATTR_SETKIND_NP)
 
 # dependencies - openssl
 if(ENABLE_TLS OR ENABLE_DNSSEC OR ENABLE_SSH)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -73,4 +73,7 @@
  */
 #define NC_PS_QUEUE_SIZE @MAX_PSPOLL_THREAD_COUNT@
 
+/* Portability feature-check macros. */
+#cmakedefine HAVE_PTHREAD_RWLOCKATTR_SETKIND_NP
+
 #endif /* NC_CONFIG_H_ */

--- a/src/session_server.c
+++ b/src/session_server.c
@@ -560,6 +560,7 @@ nc_server_init(struct ly_ctx *ctx)
     errno=0;
 
     if (pthread_rwlockattr_init(&attr) == 0) {
+#if defined(HAVE_PTHREAD_RWLOCKATTR_SETKIND_NP)
         if (pthread_rwlockattr_setkind_np(&attr, PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP) == 0) {
             if (pthread_rwlock_init(&server_opts.endpt_lock, &attr) != 0) {
                 ERR("%s: failed to init rwlock(%s).", __FUNCTION__, strerror(errno));
@@ -570,6 +571,7 @@ nc_server_init(struct ly_ctx *ctx)
         } else {
             ERR("%s: failed set attribute (%s).", __FUNCTION__, strerror(errno));
         }
+#endif
         pthread_rwlockattr_destroy(&attr);
     } else {
         ERR("%s: failed init attribute (%s).", __FUNCTION__, strerror(errno));


### PR DESCRIPTION
musl does not support pthread_rwlockattr_setkind_np. Don't use it if it is
not available.

Based on: https://github.com/openwrt/packages/blob/master/libs/libnetconf2/patches/001-fix-pthread-error