### PR TITLE
Fix format security warning in newer GCC

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -62,7 +62,7 @@ nc_ssl_error_get_reasons(void)
             ERRMEM;
             return NULL;
         }
-        reason_len += sprintf(reasons + reason_len, ERR_reason_error_string(e));
+        reason_len += sprintf(reasons + reason_len, "%s", ERR_reason_error_string(e));
     }
 
     return reasons;


### PR DESCRIPTION
In OpenWrt, -Werror=format-string is passed, making this fail compilation.

printf style functions are meant to work with format strings anyway.