### PR TITLE
Fix issue where thread specific data is dereferenced inside the key value destructor

### DIFF
--- a/src/session_client.c
+++ b/src/session_client.c
@@ -97,15 +97,25 @@ nc_client_context_free(void *ptr)
 #endif
     {
         /* for the main thread the same is done in nc_client_destroy() */
-        nc_client_set_schema_searchpath(NULL);
+        free(c->opts.schema_searchpath);
+
 #if defined(NC_ENABLED_SSH) || defined(NC_ENABLED_TLS)
-        nc_client_ch_del_bind(NULL, 0, 0);
+        int i;
+        for (i = 0; i < c->opts.ch_bind_count; ++i) {
+            close(c->opts.ch_binds[i].sock);
+            free((char *)c->opts.ch_binds[i].address);
+        }
+        free(c->opts.ch_binds);
+        c->opts.ch_binds = NULL;
+        c->opts.ch_bind_count = 0;
 #endif
 #ifdef NC_ENABLED_SSH
-        nc_client_ssh_destroy_opts();
+        _nc_client_ssh_destroy_opts(&c->ssh_opts);
+        _nc_client_ssh_destroy_opts(&c->ssh_ch_opts);
 #endif
 #ifdef NC_ENABLED_TLS
-        nc_client_tls_destroy_opts();
+        _nc_client_tls_destroy_opts(&c->tls_opts);
+        _nc_client_tls_destroy_opts(&c->tls_ch_opts);
 #endif
         free(c);
     }

--- a/src/session_client_ssh.c
+++ b/src/session_client_ssh.c
@@ -152,7 +152,7 @@ nc_close_inout(FILE *inout, int echo, struct termios *oldterm)
     }
 }
 
-static void
+void
 _nc_client_ssh_destroy_opts(struct nc_client_ssh_opts *opts)
 {
     int i;

--- a/src/session_client_tls.c
+++ b/src/session_client_tls.c
@@ -234,7 +234,7 @@ tlsauth_verify_callback(int preverify_ok, X509_STORE_CTX *x509_ctx)
 
 #endif
 
-static void
+void
 _nc_client_tls_destroy_opts(struct nc_client_tls_opts *opts)
 {
     free(opts->cert_path);

--- a/src/session_p.h
+++ b/src/session_p.h
@@ -707,6 +707,7 @@ int nc_sshcb_msg(ssh_session sshsession, ssh_message msg, void *data);
 void nc_server_ssh_clear_opts(struct nc_server_ssh_opts *opts);
 
 void nc_client_ssh_destroy_opts(void);
+void _nc_client_ssh_destroy_opts(struct nc_client_ssh_opts *opts);
 
 #endif /* NC_ENABLED_SSH */
 
@@ -727,6 +728,7 @@ int nc_accept_tls_session(struct nc_session *session, int sock, int timeout);
 void nc_server_tls_clear_opts(struct nc_server_tls_opts *opts);
 
 void nc_client_tls_destroy_opts(void);
+void _nc_client_tls_destroy_opts(struct nc_client_tls_opts *opts);
 
 #endif /* NC_ENABLED_TLS */
 


### PR DESCRIPTION
The destructor nc_client_context_free() calls out to internals which ultimately call nc_client_context_location(). This function uses pthread_getspecific() to get the thread-specific context data, creating it if it does not exist.

When called by the destructor, pthread_getspecific() returns NULL because the thread-specific data is being destroyed. (see pthread_key_create(3)). This causes a thread-specific context to be allocated while the thread's context is being destroyed, leading to nasty effects including segfaults especially when more than one thread is used.

The change replaces the internal API calls with calls which use a specific context location.