### PR TITLE
Wrong umask prevents temporary private key access

### DIFF
--- a/src/session_server_ssh.c
+++ b/src/session_server_ssh.c
@@ -46,7 +46,7 @@ base64der_key_to_tmp_file(const char *in, int rsa)
         return NULL;
     }
 
-    umode = umask(0600);
+    umode = umask(0177);
     fd = mkstemp(path);
     umask(umode);
     if (fd == -1) {


### PR DESCRIPTION
Hi,
umask 0600 prevents the user from reading his own temporary private key file.
0177 might be the intended mask.
Kind regards.