### PR TITLE
session_client: fix segfault on NC_MSG_REPLY_ERR_MSGID

### DIFF
--- a/src/session_client.c
+++ b/src/session_client.c
@@ -379,12 +379,12 @@ retrieve_schema_data_getschema(const char *name, const char *rev, struct clb_dat
 
     do {
         msg = nc_recv_reply(clb_data->session, rpc, msgid, NC_READ_ACT_TIMEOUT * 1000, 0, &reply);
-    } while (msg == NC_MSG_NOTIF);
+    } while (msg == NC_MSG_NOTIF || msg == NC_MSG_REPLY_ERR_MSGID);
     nc_rpc_free(rpc);
     if (msg == NC_MSG_WOULDBLOCK) {
         ERR("Session %u: timeout for receiving reply to a <get-schema> expired.", clb_data->session->id);
         return NULL;
-    } else if (msg == NC_MSG_ERROR) {
+    } else if (msg == NC_MSG_ERROR || reply == NULL) {
         ERR("Session %u: failed to receive a reply to <get-schema>.", clb_data->session->id);
         return NULL;
     }
@@ -710,11 +710,11 @@ build_schema_info_yl(struct nc_session *session, struct schema_info **result)
 
     do {
         msg = nc_recv_reply(session, rpc, msgid, NC_READ_ACT_TIMEOUT * 1000, 0, &reply);
-    } while (msg == NC_MSG_NOTIF);
+    } while (msg == NC_MSG_NOTIF || msg == NC_MSG_REPLY_ERR_MSGID);
     if (msg == NC_MSG_WOULDBLOCK) {
         WRN("Session %u: timeout for receiving reply to a <get> yang-library data expired.", session->id);
         goto cleanup;
-    } else if (msg == NC_MSG_ERROR) {
+    } else if (msg == NC_MSG_ERROR || reply == NULL) {
         WRN("Session %u: failed to receive a reply to <get> of yang-library data.", session->id);
         goto cleanup;
     }


### PR DESCRIPTION
When `retrieve_schema_data_getschema` or `build_schema_info_yl` receive an `NC_MSG_REPLY_ERR_MSGID` error, they do not call `nc_recv_reply` again to receive the expected message.

However, when `msg == NC_MSG_REPLY_ERR_MSGID`, `reply` is necessarily `NULL`, which causes a segfault when accessing the `reply->type` field.

Call `nc_recv_reply` again if we receive an `NC_MSG_REPLY_ERR_MSGID` error.

Also, `nc_recv_reply` may leave `reply` `NULL` for other reasons (`NC_MSG_ERROR`
is not the only case). Return an error if reply is `NULL` to avoid potential further segfaults.