### PR TITLE
session_client: fix user searchpath for unix/fd transports

### DIFF
--- a/src/session_client.c
+++ b/src/session_client.c
@@ -1098,18 +1098,10 @@ nc_connect_inout(int fdin, int fdout, struct ly_ctx *ctx)
     session->ti.fd.in = fdin;
     session->ti.fd.out = fdout;
 
-    /* assign context (dicionary needed for handshake) */
-    if (!ctx) {
-        ctx = ly_ctx_new(NC_SCHEMAS_DIR, LY_CTX_NOYANGLIBRARY);
-        /* definitely should not happen, but be ready */
-        if (!ctx && !(ctx = ly_ctx_new(NULL, 0))) {
-            /* that's just it */
-            goto fail;
-        }
-    } else {
-        session->flags |= NC_SESSION_SHAREDCTX;
+    if (nc_session_new_ctx(session, ctx) != EXIT_SUCCESS) {
+        goto fail;
     }
-    session->ctx = ctx;
+    ctx = session->ctx;
 
     /* NETCONF handshake */
     if (nc_handshake_io(session) != NC_MSG_HELLO) {
@@ -1182,18 +1174,10 @@ nc_connect_unix(const char *address, struct ly_ctx *ctx)
     session->ti.unixsock.sock = sock;
     sock = -1; /* do not close sock in fail label anymore */
 
-    /* assign context (dictionary needed for handshake) */
-    if (!ctx) {
-        ctx = ly_ctx_new(NC_SCHEMAS_DIR, LY_CTX_NOYANGLIBRARY);
-        /* definitely should not happen, but be ready */
-        if (!ctx && !(ctx = ly_ctx_new(NULL, 0))) {
-            /* that's just it */
-            goto fail;
-        }
-    } else {
-        session->flags |= NC_SESSION_SHAREDCTX;
+    if (nc_session_new_ctx(session, ctx) != EXIT_SUCCESS) {
+        goto fail;
     }
-    session->ctx = ctx;
+    ctx = session->ctx;
 
     session->path = lydict_insert(ctx, address, 0);
 


### PR DESCRIPTION
The `nc_session_new_ctx()` function creates a fresh libyang context (unless an explicit context has been provided) and initializes the context search dirs with the user search path (if set) and `NC_SCHEMAS_DIR`.

This function is only called for the SSH and TLS transports. Making the user searchpath ignored when using the UNIX and FD transports. Call it for all transports.

Fixes: fd5b66899d66 ("client CHANGE rewrite loading the schemas into context when connecting to a server")
Fixes: ac7fa2fb48a3 ("add support for unix socket transport")