### PR TITLE
python: do not put generated files into the source tree

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -19,9 +19,9 @@ if (PYTHON)
     endif()
 
     configure_file(${SETUP_PY_IN} ${SETUP_PY})
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/docs/Makefile.in ${CMAKE_CURRENT_SOURCE_DIR}/docs/Makefile)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/docs/Makefile.in ${CMAKE_CURRENT_BINARY_DIR}/docs/Makefile)
 	add_custom_target(pyapi ALL COMMAND ${PYTHON} ${SETUP_PY} build -b ${PYAPI_BUILD_DIR} ${DEBUG})
-	add_custom_target(pyapidoc COMMAND make -f ${CMAKE_CURRENT_SOURCE_DIR}/docs/Makefile html)
+	add_custom_target(pyapidoc COMMAND make -f ${CMAKE_CURRENT_BINARY_DIR}/docs/Makefile html)
     execute_process(COMMAND ${PYTHON} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(plat_specific=True))"
         OUTPUT_VARIABLE PYTHON_MODULE_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
     install(CODE "execute_process(COMMAND ${PYTHON} ${SETUP_PY} build -b ${PYAPI_BUILD_DIR} install --install-lib=\$ENV{DESTDIR}/${PYTHON_MODULE_PATH})")


### PR DESCRIPTION
Untracked content shows up in git submodules, causing stuff to be marked "dirty" by various git-level tools.

Tested by temporarily putting the resulting target within `ALL`. The result is the same as without this change (and it remains unusable with no generated index, at least when building out-of-tree, BTW).