### PR TITLE
URL capability MUST contain a scheme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.6)
 
-project(libnetconf2 LANGUAGES C)
+project(libnetconf2 C)
 
 include(GNUInstallDirs)
 include(CheckFunctionExists)

--- a/src/session.c
+++ b/src/session.c
@@ -965,6 +965,15 @@ nc_server_get_cpblts_version(struct ly_ctx *ctx, LYS_VERSION version)
         if (lys_features_state(mod, "startup") == 1) {
             add_cpblt(ctx, "urn:ietf:params:netconf:capability:startup:1.0", &cpblts, &size, &count);
         }
+        /* 
+        The URL capability must be set manually using nc_server_set_capability()
+        because of the need for supported protocols to be included.
+        https://tools.ietf.org/html/rfc6241#section-8.8.3
+        */
+        // if (lys_features_state(mod, "url") == 1) {
+        //    add_cpblt(ctx, "urn:ietf:params:netconf:capability:url:1.0", &cpblts, &size, &count);
+        // }
+        
         if (lys_features_state(mod, "xpath") == 1) {
             add_cpblt(ctx, "urn:ietf:params:netconf:capability:xpath:1.0", &cpblts, &size, &count);
         }

--- a/src/session.c
+++ b/src/session.c
@@ -965,9 +965,6 @@ nc_server_get_cpblts_version(struct ly_ctx *ctx, LYS_VERSION version)
         if (lys_features_state(mod, "startup") == 1) {
             add_cpblt(ctx, "urn:ietf:params:netconf:capability:startup:1.0", &cpblts, &size, &count);
         }
-        if (lys_features_state(mod, "url") == 1) {
-            add_cpblt(ctx, "urn:ietf:params:netconf:capability:url:1.0", &cpblts, &size, &count);
-        }
         if (lys_features_state(mod, "xpath") == 1) {
             add_cpblt(ctx, "urn:ietf:params:netconf:capability:xpath:1.0", &cpblts, &size, &count);
         }


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc6241#section-8.8.3, the URL Capability Identifier MUST contain a scheme argument.

Hence, this capability cannot be merely infered from ietf-netconf's features. It has to be explicitly provided using for example
nc_server_set_capability("urn:ietf:params:netconf:capability:url:1.0?scheme=scp,http,https,ftp,sftp,ftps,file");

Since add_cpblt() cannot overwrite capabilities, the incomplete one "urn:ietf:params:netconf:capability:url:1.0" should not be added in the first place.

This bug prevents yangcli from proposing url leaves, as no protocol can be validated against that incomplete capability identifier.