### PR TITLE
libnetconf2 CHANGE QNX compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,8 +251,13 @@ if(ENABLE_SSH)
     include_directories(${LIBSSH_INCLUDE_DIRS})
 
     # crypt
-    target_link_libraries(netconf2 -lcrypt)
-    list(APPEND CMAKE_REQUIRED_LIBRARIES crypt)
+    if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "QNX")
+        target_link_libraries(netconf2 -lcrypt)
+        list(APPEND CMAKE_REQUIRED_LIBRARIES crypt)
+    else()
+        target_link_libraries(netconf2 -llogin)
+        list(APPEND CMAKE_REQUIRED_LIBRARIES login)
+    endif()
 endif()
 
 # dependencies - libval
@@ -267,6 +272,20 @@ endif()
 find_package(LibYANG REQUIRED)
 target_link_libraries(netconf2 ${LIBYANG_LIBRARIES})
 include_directories(${LIBYANG_INCLUDE_DIRS})
+
+# header file compatibility - shadow.h and crypt.h
+check_include_file("shadow.h" HAVE_SHADOW)
+check_include_file("crypt.h" HAVE_CRYPT)
+
+# function compatibility - getpeereid on QNX
+if(${CMAKE_SYSTEM_NAME} MATCHES "QNX")
+    target_link_libraries(netconf2 -lsocket)
+    list(APPEND CMAKE_REQUIRED_LIBRARIES socket)
+    list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES pthread)
+    list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_QNX_SOURCE)
+    check_symbol_exists(getpeereid "sys/types.h;unistd.h" HAVE_GETPEEREID)
+    list(REMOVE_ITEM CMAKE_REQUIRED_DEFINITIONS -D_QNX_SOURCE)
+endif()
 
 # generate doxygen documentation for libnetconf2 API
 find_package(Doxygen)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -48,6 +48,21 @@
 #cmakedefine HAVE_PTHREAD_MUTEX_TIMEDLOCK
 
 /*
+ * Support for getpeereid
+ */
+#cmakedefine HAVE_GETPEEREID
+
+/*
+ * Support for shadow file manipulation
+ */
+#cmakedefine HAVE_SHADOW
+
+/*
+ * Support for crypt.h
+ */
+#cmakedefine HAVE_CRYPT
+
+/*
  * Location of installed basic YIN/YANG schemas
  */
 #define NC_SCHEMAS_DIR "@SCHEMAS_DIR@"

--- a/src/session_server.c
+++ b/src/session_server.c
@@ -11,6 +11,7 @@
  *
  *     https://opensource.org/licenses/BSD-3-Clause
  */
+#define _QNX_SOURCE /* getpeereid */
 #define _GNU_SOURCE /* signals, threads, SO_PEERCRED */
 
 #include <stdint.h>
@@ -1720,24 +1721,35 @@ nc_ps_clear(struct nc_pollsession *ps, int all, void (*data_free)(void *))
 static int
 nc_accept_unix(struct nc_session *session, int sock)
 {
-#ifdef SO_PEERCRED
+#if defined(SO_PEERCRED) || defined(HAVE_GETPEEREID)
     const struct passwd *pw;
-    struct ucred ucred;
     char *username;
-    socklen_t len;
     session->ti_type = NC_TI_UNIX;
+    uid_t uid;
 
-    len = sizeof(ucred);
-    if (getsockopt(sock, SOL_SOCKET, SO_PEERCRED, &ucred, &len) < 0) {
-        ERR("Failed to get credentials from unix socket (%s).",
-            strerror(errno));
-        close(sock);
-        return -1;
-    }
+    #ifdef SO_PEERCRED
+        struct ucred ucred;
+        socklen_t len;
+        len = sizeof(ucred);
+        if (getsockopt(sock, SOL_SOCKET, SO_PEERCRED, &ucred, &len) < 0) {
+            ERR("Failed to get credentials from unix socket (%s).",
+                strerror(errno));
+            close(sock);
+            return -1;
+        }
+        uid = ucred.uid;
+    #else
+        if (getpeereid(sock, &uid, NULL) < 0) {
+            ERR("Failed to get credentials from unix socket (%s).",
+                strerror(errno));
+            close(sock);
+            return -1;
+        }
+    #endif
 
-    pw = getpwuid(ucred.uid);
+    pw = getpwuid(uid);
     if (pw == NULL) {
-        ERR("Failed to find username for uid=%u (%s).\n", ucred.uid,
+        ERR("Failed to find username for uid=%u (%s).\n", uid,
             strerror(errno));
         close(sock);
         return -1;


### PR DESCRIPTION
fixes #217 
Below is a summary of the compatibility issues this solves:
1. Links against `liblogin` for QNX only
1. Checks if `crypt.h`, `shadow.h` exists instead of relying on OS checks
1. Accommodates different function signature for `getspnam_r` under QNX
1. Uses `getpeereid` for QNX only. This is because `-D_XOPEN_SOURCE=500` in CMakeLists.txt caused conflict with `-D_POSIX_C_SOURCE=200809L` and using `#define _XOPEN_SOURCE 500` in `session_server.c` caused a host of issues with pthread stuff. `libpthread` is removed from CMAKE_REQUIRED_LIBRARIES as it cmake failed to link while looking for `getpeereid`. `libpthread` is replaced by `libc` on QNX.
Other than those issues, I don't have a BSD/MAC system to test this against, so restricted it to QNX to avoid causing regression issues.