### PR TITLE
cherry-pick DSA -> ECDSA from develop

### DIFF
--- a/tests/test_server_thread.c
+++ b/tests/test_server_thread.c
@@ -202,7 +202,7 @@ ssh_endpt_del_authkey_thread(void *arg)
 
     pthread_barrier_wait(&barrier);
 
-    ret = nc_server_ssh_del_authkey(TESTS_DIR"/data/key_ecdsa.pub", NULL, 0, "test2");
+    ret = nc_server_ssh_del_authkey(TESTS_DIR"/data/key_dsa.pub", NULL, 0, "test2");
     nc_assert(!ret);
 
     return NULL;
@@ -235,7 +235,7 @@ ssh_client_thread(void *arg)
     ret = nc_client_ssh_set_username("test");
     nc_assert(!ret);
 
-    ret = nc_client_ssh_add_keypair(TESTS_DIR"/data/key_dsa.pub", TESTS_DIR"/data/key_dsa");
+    ret = nc_client_ssh_add_keypair(TESTS_DIR"/data/key_ecdsa.pub", TESTS_DIR"/data/key_ecdsa");
     nc_assert(!ret);
 
     nc_client_ssh_set_auth_pref(NC_SSH_AUTH_PUBLICKEY, 1);
@@ -681,7 +681,7 @@ main(void)
     nc_assert(!ret);
     ret = nc_server_endpt_set_port("main_ssh", 6001);
     nc_assert(!ret);
-    ret = nc_server_ssh_add_authkey_path(TESTS_DIR"/data/key_dsa.pub", "test");
+    ret = nc_server_ssh_add_authkey_path(TESTS_DIR"/data/key_ecdsa.pub", "test");
     nc_assert(!ret);
     ret = nc_server_ssh_endpt_add_hostkey("main_ssh", "key_rsa", -1);
     nc_assert(!ret);
@@ -692,7 +692,7 @@ main(void)
     ++clients;
 
     /* for ssh_endpt_del_authkey */
-    ret = nc_server_ssh_add_authkey_path(TESTS_DIR"/data/key_ecdsa.pub", "test2");
+    ret = nc_server_ssh_add_authkey_path(TESTS_DIR"/data/key_dsa.pub", "test2");
     nc_assert(!ret);
 
     ret = nc_server_add_endpt("secondary", NC_TI_LIBSSH);


### PR DESCRIPTION
This is required to keep libnetconf2's test suite working on recent distros such as Fedora 31 because they [block DSA keys](https://src.fedoraproject.org/rpms/libssh/blob/f31/f/libssh_server.config) via their `/etc/crypto-policies/back-ends/libssh.config`:
```console-session
[ci@f31-metacentrum-0000004457 libnetconf2]$ cat /etc/crypto-policies/back-ends/libssh.config
Ciphers aes256-gcm@openssh.com,chacha20-poly1305@openssh.com,aes256-ctr,aes256-cbc,aes128-gcm@openssh.com,aes128-ctr,aes128-cbc
MACs hmac-sha2-256-etm@openssh.com,hmac-sha1-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha1,hmac-sha2-512
KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1,diffie-hellman-group1-sha1
HostKeyAlgorithms rsa-sha2-256,rsa-sha2-256-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384,ecdsa-sha2-nistp384-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,ecdsa-sha2-nistp521,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,ssh-rsa,ssh-rsa-cert-v01@openssh.com
PubkeyAcceptedKeyTypes rsa-sha2-256,rsa-sha2-256-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384,ecdsa-sha2-nistp384-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,ecdsa-sha2-nistp521,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,ssh-rsa,ssh-rsa-cert-v01@openssh.com
```
...so the test suite [fails there](https://zuul.gerrit.cesnet.cz/t/public/build/5aa7810b1b4c4d41be862ece2a5a385f). When I enabled extra debugging, this is what I got:
```
[INF]: Interactive SSH authentication method was disabled.
[INF]: Password SSH authentication method was disabled.
[INF]: Publickey athentication.
[INF]: Trying to authenticate using pair "/home/ci/src/cesnet-gerrit-public/CzechLight/dependencies/libnetconf2/tests//data/key_dsa" "/home/ci/src/cesnet-gerrit-public/CzechLight/dependencies/libnetconf2/tests//data/key_dsa.pub".
[2020/04/20 09:28:39.601103, 3] ssh_key_algorithm_allowed:  Checking ssh-dss with list <rsa-sha2-256,rsa-sha2-256-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384,ecdsa-sha2-nistp384-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,ecdsa-sha2-nistp521,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,ssh-rsa,ssh-rsa-cert-v01@openssh.com>
[2020/04/20 09:28:39.601168, 1] ssh_userauth_try_publickey:  The key algorithm 'ssh-dss' is not allowed to be used by PUBLICKEY_ACCEPTED_TYPES configuration option
[WRN]: Authentication denied.
[ERR]: Unable to authenticate to the remote server (all attempts via supported authentication methods failed).
[2020/04/20 09:28:39.601351, 3] ssh_socket_unbuffered_write:  Enabling POLLOUT for socket
[2020/04/20 09:28:39.601393, 3] packet_send2:  packet: wrote [type=1, len=32, padding_size=11, comp=20, payload=20]
[ERR]: Communication SSH socket unexpectedly closed.
assert failed (/home/ci/src/cesnet-gerrit-public/CzechLight/dependencies/libnetconf2/tests/test_server_thread.c:248)
assert failed (/home/ci/src/cesnet-gerrit-public/CzechLight/dependencies/libnetconf2/tests/test_server_thread.c:70)
```