### PR TITLE
build CHANGE remove safety check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,15 +72,6 @@ if(ENABLE_DNSSEC AND NOT ENABLE_SSH)
     set(ENABLE_DNSSEC OFF)
 endif()
 
-if(ENABLE_SSH)
-    find_library(LIBCRYPT crypt)
-    if(LIBCRYPT STREQUAL LIBCRYPT-NOTFOUND)
-        message(WARNING "LIBCRYPT not found! SSH, and TLS support disabled.")
-        set(ENABLE_SSH OFF)
-        set(ENABLE_TLS OFF)
-    endif()
-endif()
-
 # package options
 find_program(DEB_BUILDER NAMES debuild)
 find_program(RPM_BUILDER NAMES rpmbuild)


### PR DESCRIPTION
Refs #217
Removing the check for `libcrypt`. One reason is that `libcrypt` is linked later on so any checking should be done there. Second reason is some platforms might implement this functionality in a different library (e.g., QNX with `liblogin`). Also, the check can be bypassed by setting `-DLIBCRYPT`.
The failure will be clear enough to indicate to the user what went wrong during compilation. Opted not to use `find_library` to look for the appropriate library, as couldn't get it to find `liblogin`.