### PR TITLE
Get the alarm content when connect_ssh_session is failed

### DIFF
--- a/src/session_client_ssh.c
+++ b/src/session_client_ssh.c
@@ -1661,6 +1661,10 @@ _nc_connect_libssh(ssh_session ssh_session, struct ly_ctx *ctx, struct nc_keepal
     return session;
 
 fail:
+    {
+		char *alarm_content = ssh_get_error(session->ti.libssh.session);
+        VRB("alarm_content is: %s", alarm_content);
+    }
     free(host);
     session->host = NULL;
     free(username);


### PR DESCRIPTION
As netconf client, we want to get the alarm content when connect_ssh_session is failed.
We can get the alarm content by call libssh interface.