### PR TITLE
travis FEATURE add sanitizer test job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,20 @@ matrix:
       dist: trusty
       sudo: required
       compiler: clang
+      env: SANITIZE="OFF"
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: clang
+      env: SANITIZE="ON"
     - os: linux
       dist: trusty
       sudo: required
       compiler: gcc
+      env: SANITIZE="OFF"
     - os: osx
       compiler: gcc
+      env: SANITIZE="OFF"
   allow_failures:
     - os: osx
 
@@ -28,11 +36,12 @@ before_install:
 
 script:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export OPENSSLFLAGS="-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl"; fi
-  - cd $TRAVIS_BUILD_DIR && mkdir build_none && cd build_none ; cmake -DENABLE_TLS=OFF -DENABLE_SSH=OFF -DENABLE_DNSSEC=OFF .. && make -j2 && ctest --output-on-failure
-  - cd $TRAVIS_BUILD_DIR && mkdir build_tls && cd build_tls ; cmake $OPENSSLFLAGS -DENABLE_TLS=ON -DENABLE_SSH=OFF -DENABLE_DNSSEC=OFF .. && make -j2 && ctest --output-on-failure
-  - cd $TRAVIS_BUILD_DIR && mkdir build_ssh && cd build_ssh ; cmake $OPENSSLFLAGS -DENABLE_TLS=OFF -DENABLE_SSH=ON -DENABLE_DNSSEC=OFF .. && make -j2 && ctest --output-on-failure
-  - cd $TRAVIS_BUILD_DIR && mkdir build_ssh_tls && cd build_ssh_tls ; cmake $OPENSSLFLAGS -DENABLE_TLS=ON -DENABLE_SSH=ON -DENABLE_DNSSEC=OFF .. && make -j2 && ctest --output-on-failure
-  - cd $TRAVIS_BUILD_DIR && mkdir build_all && cd build_all ; cmake $OPENSSLFLAGS -DENABLE_TLS=ON -DENABLE_SSH=ON -DENABLE_DNSSEC=ON .. && make -j2 && ctest --output-on-failure
+  - if [ "$SANITIZE" = "ON" ]; then export SANITIZEFLAGS='-DCMAKE_C_FLAGS="-fsanitize=address,undefined" -DENABLE_VALGRIND_TESTS=OFF'; fi
+  - cd $TRAVIS_BUILD_DIR && mkdir build_none && cd build_none ; cmake -DENABLE_TLS=OFF -DENABLE_SSH=OFF -DENABLE_DNSSEC=OFF $SANITIZEFLAGS .. && make -j2 && ctest --output-on-failure
+  - cd $TRAVIS_BUILD_DIR && mkdir build_tls && cd build_tls ; cmake $OPENSSLFLAGS -DENABLE_TLS=ON -DENABLE_SSH=OFF -DENABLE_DNSSEC=OFF $SANITIZEFLAGS .. && make -j2 && ctest --output-on-failure
+  - cd $TRAVIS_BUILD_DIR && mkdir build_ssh && cd build_ssh ; cmake $OPENSSLFLAGS -DENABLE_TLS=OFF -DENABLE_SSH=ON -DENABLE_DNSSEC=OFF $SANITIZEFLAGS .. && make -j2 && ctest --output-on-failure
+  - cd $TRAVIS_BUILD_DIR && mkdir build_ssh_tls && cd build_ssh_tls ; cmake $OPENSSLFLAGS -DENABLE_TLS=ON -DENABLE_SSH=ON -DENABLE_DNSSEC=OFF $SANITIZEFLAGS .. && make -j2 && ctest --output-on-failure
+  - cd $TRAVIS_BUILD_DIR && mkdir build_all && cd build_all ; cmake $OPENSSLFLAGS -DENABLE_TLS=ON -DENABLE_SSH=ON -DENABLE_DNSSEC=ON $SANITIZEFLAGS .. && make -j2 && ctest --output-on-failure
   - cd -
 
 after_success:


### PR DESCRIPTION
Hello,

this adds a test job that runs unit tests with ASAN and UBSAN enabled. Valgrind tests are disabled in that case, just like in the recent [sysrepo](https://github.com/sysrepo/sysrepo/pull/2212) and [libyang](https://github.com/CESNET/libyang/pull/1261) PRs, as valgrind can't run when sanitizer support is compiled in. I've tested that the .travis.yml works on a fork. If there are any comments or changes that should be made please let me know.