### PR TITLE
Fix libyang error when setting confirmed commit

### DIFF
--- a/src/session_client.c
+++ b/src/session_client.c
@@ -2661,13 +2661,15 @@ nc_send_rpc(struct nc_session *session, struct nc_rpc *rpc, int timeout, uint64_
         rpc_com = (struct nc_rpc_commit *)rpc;
 
         data = lyd_new(NULL, mod, "commit");
-        if (rpc_com->confirmed) {
-            lyd_new_leaf(data, mod, "confirmed", NULL);
-        }
+        if (lys_features_state(mod, "confirmed-commit")) {
+            if (rpc_com->confirmed) {
+                lyd_new_leaf(data, mod, "confirmed", NULL);
+            }
 
-        if (rpc_com->confirm_timeout) {
-            sprintf(str, "%u", rpc_com->confirm_timeout);
-            lyd_new_leaf(data, mod, "confirm-timeout", str);
+            if (rpc_com->confirm_timeout) {
+                sprintf(str, "%u", rpc_com->confirm_timeout);
+                lyd_new_leaf(data, mod, "confirm-timeout", str);
+            }
         }
 
         if (rpc_com->persist) {


### PR DESCRIPTION
When creating a commit RPC, if the ietf-netconf module doesn't have the
"confirmed-commit" feature enabled, it always prints a libyang error. This
patch adds a check for that.

Reproducer program:
```cpp
#include <libnetconf2/session_client.h>

int main(int argc, char* argv[])
{
    auto sess = nc_connect_unix("/opt/cesnet/Netopeer2/netopeer2-server.sock", nullptr);
    auto rpc = nc_rpc_commit(1, 0, nullptr, nullptr, NC_PARAMTYPE_CONST);
    uint64_t id;
    nc_send_rpc(sess, rpc, 0, &id);
}
```
When run, it prints:
```
$ ./a.out 
libyang[0]: Failed to find "confirmed" as a sibling to "ietf-netconf:confirmed".
```