### PR TITLE
session server BUGFIX in nc_sock_accept_binds

### DIFF
--- a/src/session_server.c
+++ b/src/session_server.c
@@ -458,14 +458,20 @@ nc_sock_accept_binds(struct nc_bind *binds, uint16_t bind_count, int timeout, ch
                 ERRMEM;
             }
         } else if (saddr.ss_family == AF_UNIX) {
-            *host = strdup(((struct sockaddr_un *)&saddr)->sun_path);
-            if (*host) {
-                if (port) {
-                    *port = 0;
+            saddr_len = sizeof(saddr);
+            if (getsockname(ret, (struct sockaddr *)&saddr, &saddr_len) == 0) {
+                *host = strdup(((struct sockaddr_un *)&saddr)->sun_path);
+                if (*host) {
+                    if (port) {
+                        *port = 0;
+                    }
+                } else {
+                    ERRMEM;
                 }
             } else {
-                ERRMEM;
+                ERR("getsockname failed (%s).", strerror(errno));
             }
+
         } else {
             ERR("Source host of an unknown protocol family.");
         }

--- a/src/session_server.c
+++ b/src/session_server.c
@@ -384,7 +384,7 @@ sock_host_inet(const struct sockaddr_in *addr, char **host, uint16_t *port)
         return -1;
     }
 
-    if (!inet_ntop(AF_INET, &addr->sin_addr.s_addr, *host, INET_ADDRSTRLEN)) {
+    if (!inet_ntop(AF_INET, &addr->sin_addr, *host, INET_ADDRSTRLEN)) {
         ERR("inet_ntop failed(%s).");
         free(*host);
         *host = NULL;
@@ -415,7 +415,7 @@ sock_host_inet6(const struct sockaddr_in6 *addr, char **host, uint16_t *port)
         return -1;
     }
 
-    if (!inet_ntop(AF_INET6, &addr->sin6_addr.s6_addr, *host, INET6_ADDRSTRLEN)) {
+    if (!inet_ntop(AF_INET6, &addr->sin6_addr, *host, INET6_ADDRSTRLEN)) {
         ERR("inet_ntop failed(%s).");
         free(*host);
         *host = NULL;


### PR DESCRIPTION
After this correction, the correct sun_path is written to the host pointer and not garbage.
Parameter src in function inet_ntop has also changed to a much safer form.