### PR TITLE
Fix _nc_connect_libssh port on big endian processors

### DIFF
--- a/src/session_client_ssh.c
+++ b/src/session_client_ssh.c
@@ -1537,7 +1537,7 @@ _nc_connect_libssh(ssh_session ssh_session, struct ly_ctx *ctx, struct nc_keepal
         struct nc_client_ssh_opts *opts, int timeout)
 {
     char *host = NULL, *username = NULL, *ip_host;
-    unsigned short port = 0;
+    unsigned int port = 0;
     int sock;
     struct passwd *pw;
     struct nc_session *session = NULL;


### PR DESCRIPTION
See, gets cast to (unsigned int*):
1561 ssh_options_get_port(ssh_session, (unsigned int *)&port);