### PR TITLE
libnetconf2 BUGFIX netopeer2 build fails when building with musl libc

### DIFF
--- a/src/session_server.h
+++ b/src/session_server.h
@@ -19,6 +19,7 @@
 extern "C" {
 #endif
 
+#include <sys/types.h>
 #include <libyang/libyang.h>
 #include <stdint.h>
 


### PR DESCRIPTION
while updating buildroot package this failure was observed during package testing