### PR TITLE
Get rid of volatile in favor of ATOMIC_T

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -29,7 +29,7 @@
 /**
  * @brief libnetconf verbose level variable
  */
-volatile uint8_t verbose_level = 0;
+ATOMIC_T verbose_level = 0;
 
 void (*depr_print_clb)(NC_VERB_LEVEL level, const char *msg);
 void (*print_clb)(const struct nc_session *session, NC_VERB_LEVEL level, const char *msg);
@@ -37,7 +37,7 @@ void (*print_clb)(const struct nc_session *session, NC_VERB_LEVEL level, const c
 API void
 nc_verbosity(NC_VERB_LEVEL level)
 {
-    verbose_level = level;
+    ATOMIC_STORE_RELAXED(verbose_level, level);
     ly_log_level((LY_LOG_LEVEL)level);
 }
 

--- a/src/log_p.h
+++ b/src/log_p.h
@@ -18,6 +18,7 @@
 
 #include <stdint.h>
 
+#include "compat.h"
 #include "log.h"
 
 /*
@@ -36,16 +37,16 @@ void prv_printf(const struct nc_session *session, NC_VERB_LEVEL level, const cha
 /**
  * @brief Verbose level variable
  */
-extern volatile uint8_t verbose_level;
+extern ATOMIC_T verbose_level;
 
 /*
  * Verbose printing macros
  */
 #define ERR(session, format, args ...) prv_printf(session,NC_VERB_ERROR,format,##args)
-#define WRN(session, format, args ...) if(verbose_level>=NC_VERB_WARNING){prv_printf(session,NC_VERB_WARNING,format,##args);}
-#define VRB(session, format, args ...) if(verbose_level>=NC_VERB_VERBOSE){prv_printf(session,NC_VERB_VERBOSE,format,##args);}
-#define DBG(session, format, args ...) if(verbose_level>=NC_VERB_DEBUG){prv_printf(session,NC_VERB_DEBUG,format,##args);}
-#define DBL(session, format, args ...) if(verbose_level>=NC_VERB_DEBUG_LOWLVL){prv_printf(session,NC_VERB_DEBUG_LOWLVL,format,##args);}
+#define WRN(session, format, args ...) if(ATOMIC_LOAD_RELAXED(verbose_level)>=NC_VERB_WARNING){prv_printf(session,NC_VERB_WARNING,format,##args);}
+#define VRB(session, format, args ...) if(ATOMIC_LOAD_RELAXED(verbose_level)>=NC_VERB_VERBOSE){prv_printf(session,NC_VERB_VERBOSE,format,##args);}
+#define DBG(session, format, args ...) if(ATOMIC_LOAD_RELAXED(verbose_level)>=NC_VERB_DEBUG){prv_printf(session,NC_VERB_DEBUG,format,##args);}
+#define DBL(session, format, args ...) if(ATOMIC_LOAD_RELAXED(verbose_level)>=NC_VERB_DEBUG_LOWLVL){prv_printf(session,NC_VERB_DEBUG_LOWLVL,format,##args);}
 
 #define ERRMEM ERR(NULL, "%s: memory reallocation failed (%s:%d).", __func__, __FILE__, __LINE__)
 #define ERRARG(arg) ERR(NULL, "%s: invalid argument (%s).", __func__, arg)


### PR DESCRIPTION
Hi, these things sometimes caused errors in with ThreadSanitizer:
```
==================
WARNING: ThreadSanitizer: data race (pid=2220020)
  Write of size 1 at 0x7f4110c70c58 by main thread:
    #0 nc_verbosity /home/vk/git/netconf-cli/submodules/dependencies/libnetconf2/src/log.c:40:19 (libnetconf2.so.3+0x102ac)
    #1 libnetconf::client::setLogLevel(NC_VERB_LEVEL) /home/vk/git/netconf-cli/submodules/dependencies/libnetconf2-cpp/src/netconf-client.cpp:170:5 (libnetconf2-cpp.so+0x6c47)
    #2 DOCTEST_ANON_FUNC_2() /home/vk/git/netconf-cli/submodules/dependencies/libnetconf2-cpp/tests/client.cpp:183:5 (test_client+0xebb4f)
    #3 doctest::Context::run() /opt/cesnet-t/include/doctest/doctest.h:6510:21 (test_client+0xfc8cf)
    #4 main /opt/cesnet-t/include/doctest/doctest.h:6595:71 (test_client+0xfe1dc)

  Previous read of size 1 at 0x7f4110c70c58 by thread T1 (mutexes: write M94):
    #0 nc_read_msg_io /home/vk/git/netconf-cli/submodules/dependencies/libnetconf2/src/io.c:451:5 (libnetconf2.so.3+0xdbf7)
    #1 nc_read_msg_poll_io /home/vk/git/netconf-cli/submodules/dependencies/libnetconf2/src/io.c:599:12 (libnetconf2.so.3+0xe364)
    #2 recv_msg /home/vk/git/netconf-cli/submodules/dependencies/libnetconf2/src/session_client.c:1939:9 (libnetconf2.so.3+0x21500)
    #3 recv_reply /home/vk/git/netconf-cli/submodules/dependencies/libnetconf2/src/session_client.c:1997:11 (libnetconf2.so.3+0x1dbe1)
    #4 nc_recv_reply /home/vk/git/netconf-cli/submodules/dependencies/libnetconf2/src/session_client.c:2211:11 (libnetconf2.so.3+0x1d6a1)
    #5 retrieve_schema_data_getschema /home/vk/git/netconf-cli/submodules/dependencies/libnetconf2/src/session_client.c:410:15 (libnetconf2.so.3+0x20e44)
    #6 retrieve_schema_data /home/vk/git/netconf-cli/submodules/dependencies/libnetconf2/src/session_client.c:508:22 (libnetconf2.so.3+0x1b787)
    #7 nc_ctx_load_module /home/vk/git/netconf-cli/submodules/dependencies/libnetconf2/src/session_client.c:691:9 (libnetconf2.so.3+0x1b787)
    #8 nc_ctx_fill /home/vk/git/netconf-cli/submodules/dependencies/libnetconf2/src/session_client.c:1036:9 (libnetconf2.so.3+0x1ab4a)
    #9 nc_ctx_check_and_fill /home/vk/git/netconf-cli/submodules/dependencies/libnetconf2/src/session_client.c:1230:9 (libnetconf2.so.3+0x1ab4a)
    #10 nc_connect_inout /home/vk/git/netconf-cli/submodules/dependencies/libnetconf2/src/session_client.c:1289:9 (libnetconf2.so.3+0x1bb30)
    #11 libnetconf::client::Session::connectFd(int, int) /home/vk/git/netconf-cli/submodules/dependencies/libnetconf2-cpp/src/netconf-client.cpp:243:46 (libnetconf2-cpp.so+0x7922)
    #12 DOCTEST_ANON_FUNC_2()::$_0::operator()() const /home/vk/git/netconf-cli/submodules/dependencies/libnetconf2-cpp/tests/client.cpp:163:24 (test_client+0xec282)
    #13 void std::__invoke_impl<void, DOCTEST_ANON_FUNC_2()::$_0>(std::__invoke_other, DOCTEST_ANON_FUNC_2()::$_0&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/invoke.h:61:14 (test_client+0xec282)
    #14 std::__invoke_result<DOCTEST_ANON_FUNC_2()::$_0>::type std::__invoke<DOCTEST_ANON_FUNC_2()::$_0>(DOCTEST_ANON_FUNC_2()::$_0&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/invoke.h:96:14 (test_client+0xec282)
    #15 void std::thread::_Invoker<std::tuple<DOCTEST_ANON_FUNC_2()::$_0> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/std_thread.h:253:13 (test_client+0xec282)
    #16 std::thread::_Invoker<std::tuple<DOCTEST_ANON_FUNC_2()::$_0> >::operator()() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/std_thread.h:260:11 (test_client+0xec282)
    #17 std::thread::_State_impl<std::thread::_Invoker<std::tuple<DOCTEST_ANON_FUNC_2()::$_0> > >::_M_run() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/std_thread.h:211:13 (test_client+0xec282)
    #18 execute_native_thread_routine /build/gcc/src/gcc/libstdc++-v3/src/c++11/thread.cc:82:18 (libstdc++.so.6+0xd33c3)

  Location is global 'verbose_level' of size 1 at 0x7f4110c70c58 (libnetconf2.so.3+0x000000053c58)

  Mutex M94 (0x7b480000ff88) created at:
    #0 pthread_mutex_init <null> (test_client+0x7ba0c)
    #1 nc_new_session /home/vk/git/netconf-cli/submodules/dependencies/libnetconf2/src/session.c:199:9 (libnetconf2.so.3+0x15be9)
    #2 nc_connect_inout /home/vk/git/netconf-cli/submodules/dependencies/libnetconf2/src/session_client.c:1266:15 (libnetconf2.so.3+0x1bab7)
    #3 libnetconf::client::Session::connectFd(int, int) /home/vk/git/netconf-cli/submodules/dependencies/libnetconf2-cpp/src/netconf-client.cpp:243:46 (libnetconf2-cpp.so+0x7922)
    #4 DOCTEST_ANON_FUNC_2()::$_0::operator()() const /home/vk/git/netconf-cli/submodules/dependencies/libnetconf2-cpp/tests/client.cpp:163:24 (test_client+0xec282)
    #5 void std::__invoke_impl<void, DOCTEST_ANON_FUNC_2()::$_0>(std::__invoke_other, DOCTEST_ANON_FUNC_2()::$_0&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/invoke.h:61:14 (test_client+0xec282)
    #6 std::__invoke_result<DOCTEST_ANON_FUNC_2()::$_0>::type std::__invoke<DOCTEST_ANON_FUNC_2()::$_0>(DOCTEST_ANON_FUNC_2()::$_0&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/invoke.h:96:14 (test_client+0xec282)
    #7 void std::thread::_Invoker<std::tuple<DOCTEST_ANON_FUNC_2()::$_0> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/std_thread.h:253:13 (test_client+0xec282)
    #8 std::thread::_Invoker<std::tuple<DOCTEST_ANON_FUNC_2()::$_0> >::operator()() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/std_thread.h:260:11 (test_client+0xec282)
    #9 std::thread::_State_impl<std::thread::_Invoker<std::tuple<DOCTEST_ANON_FUNC_2()::$_0> > >::_M_run() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/std_thread.h:211:13 (test_client+0xec282)
    #10 execute_native_thread_routine /build/gcc/src/gcc/libstdc++-v3/src/c++11/thread.cc:82:18 (libstdc++.so.6+0xd33c3)

  Thread T1 (tid=2220022, running) created by main thread at:
    #0 pthread_create <null> (test_client+0x97d5a)
    #1 __gthread_create /build/gcc/src/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/include/x86_64-pc-linux-gnu/bits/gthr-default.h:663:35 (libstdc++.so.6+0xd36aa)
    #2 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) /build/gcc/src/gcc/libstdc++-v3/src/c++11/thread.cc:147:37 (libstdc++.so.6+0xd36aa)
    #3 doctest::Context::run() /opt/cesnet-t/include/doctest/doctest.h:6510:21 (test_client+0xfc8cf)
    #4 main /opt/cesnet-t/include/doctest/doctest.h:6595:71 (test_client+0xfe1dc)

SUMMARY: ThreadSanitizer: data race /home/vk/git/netconf-cli/submodules/dependencies/libnetconf2/src/log.c:40:19 in nc_verbosity
```