### PR TITLE
Update libnetconf2-dev.install

### DIFF
--- a/distro/pkg/deb/libnetconf2-dev.install
+++ b/distro/pkg/deb/libnetconf2-dev.install
@@ -3,3 +3,4 @@ usr/lib/*/pkgconfig/libnetconf2.pc
 usr/include/libnetconf2/*
 usr/include/nc_client.h
 usr/include/nc_server.h
+usr/include/nc_version.h


### PR DESCRIPTION
This file has to be present for successful CESNET/netopeer2 build (devel).
https://github.com/CESNET/netopeer2/blob/devel/CMakeModules/FindLibNETCONF2.cmake#L74