### PR TITLE
Fix segfault on malformed yang-library data

### DIFF
--- a/src/session_client.c
+++ b/src/session_client.c
@@ -825,7 +825,7 @@ build_schema_info_yl(struct nc_session *session, int has_get_data, struct schema
     } else if (msg == NC_MSG_ERROR) {
         WRN(session, "Failed to receive a reply to <%s> of yang-library data.", rpc_name);
         goto cleanup;
-    } else if (!op || !lyd_child(op) || strcmp(lyd_child(op)->schema->name, "data")) {
+    } else if (!op || !lyd_child(op) || !lyd_child(op)->schema || strcmp(lyd_child(op)->schema->name, "data")) {
         WRN(session, "Unexpected reply without data to a yang-library <%s> RPC.", rpc_name);
         goto cleanup;
     }


### PR DESCRIPTION
Our internal test suite fed mismatched replies to libnetconf2. The library was trying to request the `ietf-yang-library` data, and because of some preceding replies which sent garbage instead of that module's YANG source, the library was apparently not able to send a proper request. Instead, the following command was sent:
```
 libyang[0]: Unexpected module "ietf-yang-metadata" parsed instead of "ietf-origin").
 libyang[0]: Parsing module "ietf-yang-metadata" failed.
 libyang[0]: Loading "ietf-origin" module failed.
 libyang[0]: Parsing module "ietf-netconf-nmda" failed.
 Session 1 [INF]: Support for <get-data> from ietf-netconf-nmda not found.
 libyang[0]: Failed to resolve prefix "ietf-yang-library".
 Session 1 [DBG]: Sending message:

 #165

 Session 1 [DBG]: Sending message:
 <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="4"><get xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"><filter type="xpath" select=""/></get></rpc>
```
That in istelf is an error (libnetconf2 should have died much sooner when the server responds with garbage), but that's not what I am fixing here. Our broken test suite responded with:
```
 <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="4"><data xmlns="urn:ietf:params:xml:ns:yang:ietf-netconf-monitoring">   module ietf-yang-library {
     yang-version 1.1;
     namespace &quot;urn:ietf:params:xml:ns:yang:ietf-yang-library&quot;;
     prefix yanglib;
 ...
```
This ended up as a segfault:
```
 libnetconf2/src/session_client.c:828:71: runtime error: member access within null pointer of type 'const struct lysc_node'

 #0 0x7f4ac54350ae in build_schema_info_yl libnetconf2/src/session_client.c:828:71
 #1 0x7f4ac54350ae in nc_ctx_check_and_fill libnetconf2/src/session_client.c:1218:13
 #2 0x7f4ac54394d9 in nc_connect_inout libnetconf2/src/session_client.c:1289:9
 #3 0x7f4ac5b55201 in libnetconf::client::Session::connectFd(int, int, std::optional<libyang::Context>) libnetconf2-cpp/src/netconf-client.cpp:244:46
```
The fix prevents the segfault, and libnetconf2 now "fails cleanly" even with out broken test suite.

Another problem (libnetconf2 doesn't disconnect quickly enough when the YANG schemas requested from libyang do not match those which were actually requested) remains unfixed -- see [this log](https://github.com/CESNET/libnetconf2/files/8381698/mismatched-replies.txt) for a copy of the actual communication.
