### PR TITLE
libnetconf2 FEATURE auth using Linux PAM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - devel
 
 env:
-  DEFAULT_PACKAGES: libcmocka-dev zlib1g-dev libssh-dev libssl-dev
+  DEFAULT_PACKAGES: libcmocka-dev zlib1g-dev libssh-dev libssl-dev libpam0g-dev
 
 jobs:
   git-branch:

--- a/.github/workflows/devel-push.yml
+++ b/.github/workflows/devel-push.yml
@@ -5,7 +5,7 @@ on:
       - devel
 
 env:
-  DEFAULT_PACKAGES: libcmocka-dev zlib1g-dev libssh-dev libssl-dev
+  DEFAULT_PACKAGES: libcmocka-dev zlib1g-dev libssh-dev libssl-dev libpam0g-dev
   COVERITY_PROJECT: CESNET%2Flibnetconf2
 
 jobs:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,8 @@ set(format_sources
     src/*.c
     src/*.h
     tests/*.c
-    tests/client/*.c)
+    tests/client/*.c
+    tests/pam/*.c)
 
 #
 # checks
@@ -257,6 +258,20 @@ if(ENABLE_SSH)
         target_link_libraries(netconf2 -llogin)
         list(APPEND CMAKE_REQUIRED_LIBRARIES login)
     endif()
+
+    # libpam
+    find_package(LibPAM REQUIRED)
+
+    # enable PAM test if a PAM header file contains a declaration of a function pam_start_confdir
+    if (LIBPAM_HAVE_CONFDIR)
+      message(STATUS "LibPAM found, version >= 1.4, enabled PAM tests")
+    else()
+      message(STATUS "LibPAM found, version < 1.4, disabled PAM tests")
+    endif()
+
+    target_link_libraries(netconf2 ${LIBPAM_LIBRARIES})
+    list(APPEND CMAKE_REQUIRED_LIBRARIES ${LIBPAM_LIBRARIES})
+    include_directories(${LIBPAM_INCLUDE_DIRS})
 endif()
 
 # dependencies - libval

--- a/CMakeModules/FindLibPAM.cmake
+++ b/CMakeModules/FindLibPAM.cmake
@@ -1,0 +1,87 @@
+# - Try to find LibPAM
+# Once done this will define
+#
+#  LIBPAM_FOUND - system has LibPAM
+#  LIBPAM_INCLUDE_DIRS - the LibPAM include directory
+#  LIBPAM_LIBRARIES - link these to use LibPAM
+#  LIBPAM_HAVE_CONFDIR - LibPAM version >= 1.4
+#
+#  Author Roman Janota <xjanot04@fit.vutbr.cz>
+#  Copyright (c) 2022 CESNET, z.s.p.o.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#  1. Redistributions of source code must retain the copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. The name of the author may not be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+#  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+#  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+#  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+#  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+#  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+#  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+if(LIBPAM_LIBRARIES AND LIBPAM_INCLUDE_DIRS)
+  # in cache already
+  set(LIBPAM_FOUND TRUE)
+else()
+
+  find_path(LIBPAM_INCLUDE_DIR
+    NAMES
+      security/pam_appl.h
+      security/pam_modules.h
+    PATHS
+      /opt/local/include
+      /sw/include
+      ${CMAKE_INCLUDE_PATH}
+      ${CMAKE_INSTALL_PREFIX}/include
+  )
+
+  find_library(LIBPAM_LIBRARY
+    NAMES
+      pam
+    PATHS
+      /usr/lib
+      /usr/lib64
+      /opt/local/lib
+      /sw/lib
+      ${CMAKE_LIBRARY_PATH}
+      ${CMAKE_INSTALL_PREFIX}/lib
+  )
+
+  if(LIBPAM_INCLUDE_DIR AND LIBPAM_LIBRARY)
+    set(LIBPAM_FOUND TRUE)
+    # there is no reliable way to check the version of PAM, so see if the declaration of a function pam_start_confdir
+    # is in the header file (added in PAM 1.4)
+    file(STRINGS ${LIBPAM_INCLUDE_DIR}/security/pam_appl.h PAM_CONFDIR REGEX "pam_start_confdir")
+    if ("${PAM_CONFDIR}" STREQUAL "")
+      set(LIBPAM_HAVE_CONFDIR FALSE)
+    else()
+      set(LIBPAM_HAVE_CONFDIR TRUE)
+    endif()
+  else()
+    set(LIBPAM_FOUND FALSE)
+  endif()
+
+  set(LIBPAM_INCLUDE_DIRS ${LIBPAM_INCLUDE_DIR})
+  set(LIBPAM_LIBRARIES ${LIBPAM_LIBRARY})
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(LibPAM DEFAULT_MSG LIBPAM_LIBRARIES LIBPAM_INCLUDE_DIRS)
+
+  # show the LIBPAM_INCLUDE_DIRS and LIBPAM_LIBRARIES variables only in the advanced view
+  mark_as_advanced(LIBPAM_INCLUDE_DIRS LIBPAM_LIBRARIES)
+
+endif()

--- a/FAQ.md
+++ b/FAQ.md
@@ -7,7 +7,7 @@ __Q: Having a fresh installation of *netopeer2-server*, when I connect to it I s
 
 __A:__ You are using *libssh* that was compiled with *gcrypt* library
    as the crypto backend. It does not support default SSH keys generated
-   during *netopeer2-server* installation. To fix, disable suport for this
+   during *netopeer2-server* installation. To fix, disable support for this
    backend when compiling *libssh* so that some other one is used.
 
 __Q: When a new NETCONF session is being created, I see the error:__
@@ -36,3 +36,8 @@ __A:__ There are 2 most common reasons for this error. Either you are not using
    To fix, use a NETCONF client instead. Another reason may be that you are using *libssh*
    version 0.9.4. It includes a [regression bug](https://gitlab.com/libssh/libssh-mirror/-/merge_requests/101)
    that causes this problem and you must use another version to fix it.
+
+__Q: When I try to enter authentication tokens, they always echo back even though I set echo off:__
+
+__A:__ You are most likely using an older version of *libssh* which contains a bug.
+   The bug was fixed in *libssh* 0.9.0, so you must use at least that version.

--- a/README.md
+++ b/README.md
@@ -74,8 +74,10 @@ $ make
 ```
 
 ### libssh
-Required version is at least 0.7.1. This dependency can be removed by disabling
-SSH support (see the [Build Options](#build-options) section). Below si the basic
+Required version is at least 0.7.1. Recommended version is at least 0.9.0, because of a bug
+present in older versions, which echoes everything back when entering authentication tokens. 
+This dependency can be removed by disabling
+SSH support (see the [Build Options](#build-options) section). Below is the basic
 sequence of commands for compiling and installing it from source. However, there
 are packages for certain Linux distributions available [here](https://www.libssh.org/get-it/).
 ```
@@ -253,7 +255,7 @@ All public functions are available via 2 headers:
 #include <nc_client.h>
 ```
 
-You need to include either one if imeplementing a NETCONF server or a NETCONF client,
+You need to include either one if implementing a NETCONF server or a NETCONF client,
 respectively.
 
 To compile your program with libnetconf2, it is necessary to link it with it using the

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -39,6 +39,11 @@
 #cmakedefine HAVE_CRYPT
 
 /*
+* Support for older PAM versions
+*/
+#cmakedefine LIBPAM_HAVE_CONFDIR
+
+/*
  * Location of installed basic YANG modules on the system
  */
 #define NC_YANG_DIR "@YANG_MODULE_DIR@"

--- a/src/session.c
+++ b/src/session.c
@@ -100,16 +100,16 @@ nc_gettimespec_real_add(struct timespec *ts, uint32_t msec)
 int
 nc_gettimespec_mono_add(struct timespec *ts, uint32_t msec)
 {
-    #ifdef CLOCK_MONOTONIC_RAW
+#ifdef CLOCK_MONOTONIC_RAW
     if (clock_gettime(CLOCK_MONOTONIC_RAW, ts)) {
         return -1;
     }
-    #elif defined (CLOCK_MONOTONIC)
+#elif defined (CLOCK_MONOTONIC)
     if (clock_gettime(CLOCK_MONOTONIC, ts)) {
         return -1;
     }
-    #else
-    /* no monotonic clock available, return realtime */
+#else
+    /* no monotonic clock available, return real time */
     if (nc_gettimespec_real_add(ts, 0)) {
         return -1;
     }

--- a/src/session_client.c
+++ b/src/session_client.c
@@ -70,7 +70,7 @@ static struct nc_client_context context_main = {
     },
 #ifdef NC_ENABLED_SSH
     .ssh_opts = {
-        .auth_pref = {{NC_SSH_AUTH_INTERACTIVE, 3}, {NC_SSH_AUTH_PASSWORD, 2}, {NC_SSH_AUTH_PUBLICKEY, 1}},
+        .auth_pref = {{NC_SSH_AUTH_INTERACTIVE, 1}, {NC_SSH_AUTH_PASSWORD, 2}, {NC_SSH_AUTH_PUBLICKEY, 3}},
         .auth_hostkey_check = sshauth_hostkey_check,
         .auth_password = sshauth_password,
         .auth_interactive = sshauth_interactive,
@@ -163,17 +163,17 @@ nc_client_context_location(void)
             e->refcount = 1;
 #ifdef NC_ENABLED_SSH
             e->ssh_opts.auth_pref[0].type = NC_SSH_AUTH_INTERACTIVE;
-            e->ssh_opts.auth_pref[0].value = 3;
+            e->ssh_opts.auth_pref[0].value = 1;
             e->ssh_opts.auth_pref[1].type = NC_SSH_AUTH_PASSWORD;
             e->ssh_opts.auth_pref[1].value = 2;
             e->ssh_opts.auth_pref[2].type = NC_SSH_AUTH_PUBLICKEY;
-            e->ssh_opts.auth_pref[2].value = 1;
+            e->ssh_opts.auth_pref[2].value = 3;
             e->ssh_opts.auth_hostkey_check = sshauth_hostkey_check;
             e->ssh_opts.auth_password = sshauth_password;
             e->ssh_opts.auth_interactive = sshauth_interactive;
             e->ssh_opts.auth_privkey_passphrase = sshauth_privkey_passphrase;
 
-            /* callhome settings are the same except the inverted auth methods preferences */
+            /* callhome settings are the same */
             memcpy(&e->ssh_ch_opts, &e->ssh_opts, sizeof e->ssh_ch_opts);
             e->ssh_ch_opts.auth_pref[0].value = 1;
             e->ssh_ch_opts.auth_pref[1].value = 2;

--- a/src/session_client_ssh.c
+++ b/src/session_client_ssh.c
@@ -1173,16 +1173,14 @@ connect_ssh_session(struct nc_session *session, struct nc_client_ssh_opts *opts,
     char *s, *answer, echo;
     ssh_key pubkey, privkey;
     ssh_session ssh_sess;
-    struct timespec ts_timeout, ts_cur;
+    struct timespec ts_timeout;
 
     ssh_sess = session->ti.libssh.session;
 
-    nc_gettimespec_mono(&ts_timeout);
-    nc_addtimespec(&ts_timeout, NC_TRANSPORT_TIMEOUT);
+    nc_gettimespec_mono_add(&ts_timeout, NC_TRANSPORT_TIMEOUT);
     while ((ret = ssh_connect(ssh_sess)) == SSH_AGAIN) {
         usleep(NC_TIMEOUT_STEP);
-        nc_gettimespec_mono(&ts_cur);
-        if (nc_difftimespec(&ts_cur, &ts_timeout) < 1) {
+        if (nc_difftimespec_cur(&ts_timeout) < 1) {
             break;
         }
     }
@@ -1201,16 +1199,12 @@ connect_ssh_session(struct nc_session *session, struct nc_client_ssh_opts *opts,
     }
 
     if (timeout > -1) {
-        nc_gettimespec_mono(&ts_timeout);
-        nc_addtimespec(&ts_timeout, timeout);
+        nc_gettimespec_mono_add(&ts_timeout, timeout);
     }
     while ((ret_auth = ssh_userauth_none(ssh_sess, NULL)) == SSH_AUTH_AGAIN) {
         usleep(NC_TIMEOUT_STEP);
-        if (timeout > -1) {
-            nc_gettimespec_mono(&ts_cur);
-            if (nc_difftimespec(&ts_cur, &ts_timeout) < 1) {
-                break;
-            }
+        if ((timeout > -1) && (nc_difftimespec_cur(&ts_timeout) < 1)) {
+            break;
         }
     }
     if (ret_auth == SSH_AUTH_AGAIN) {
@@ -1279,16 +1273,12 @@ connect_ssh_session(struct nc_session *session, struct nc_client_ssh_opts *opts,
             }
 
             if (timeout > -1) {
-                nc_gettimespec_mono(&ts_timeout);
-                nc_addtimespec(&ts_timeout, timeout);
+                nc_gettimespec_mono_add(&ts_timeout, timeout);
             }
             while ((ret_auth = ssh_userauth_password(ssh_sess, session->username, s)) == SSH_AUTH_AGAIN) {
                 usleep(NC_TIMEOUT_STEP);
-                if (timeout > -1) {
-                    nc_gettimespec_mono(&ts_cur);
-                    if (nc_difftimespec(&ts_cur, &ts_timeout) < 1) {
-                        break;
-                    }
+                if ((timeout > -1) && (nc_difftimespec_cur(&ts_timeout) < 1)) {
+                    break;
                 }
             }
             memset(s, 0, strlen(s));
@@ -1301,18 +1291,14 @@ connect_ssh_session(struct nc_session *session, struct nc_client_ssh_opts *opts,
             VRB(session, "Keyboard-interactive authentication.");
 
             if (timeout > -1) {
-                nc_gettimespec_mono(&ts_timeout);
-                nc_addtimespec(&ts_timeout, timeout);
+                nc_gettimespec_mono_add(&ts_timeout, timeout);
             }
             while (((ret_auth = ssh_userauth_kbdint(ssh_sess, NULL, NULL)) == SSH_AUTH_INFO) ||
                     (ret_auth == SSH_AUTH_AGAIN)) {
                 if (ret_auth == SSH_AUTH_AGAIN) {
                     usleep(NC_TIMEOUT_STEP);
-                    if (timeout > -1) {
-                        nc_gettimespec_mono(&ts_cur);
-                        if (nc_difftimespec(&ts_cur, &ts_timeout) < 1) {
-                            break;
-                        }
+                    if ((timeout > -1) && (nc_difftimespec_cur(&ts_timeout) < 1)) {
+                        break;
                     }
                     continue;
                 }
@@ -1323,9 +1309,6 @@ connect_ssh_session(struct nc_session *session, struct nc_client_ssh_opts *opts,
                         ret_auth = SSH_AUTH_ERROR;
                         break;
                     }
-
-                    /* libssh BUG - echo is always 1 for some reason, assume always 0 */
-                    echo = 0;
 
                     answer = opts->auth_interactive(ssh_userauth_kbdint_getname(ssh_sess),
                             ssh_userauth_kbdint_getinstruction(ssh_sess),
@@ -1341,8 +1324,7 @@ connect_ssh_session(struct nc_session *session, struct nc_client_ssh_opts *opts,
                     break;
                 }
                 if (timeout > -1) {
-                    nc_gettimespec_mono(&ts_timeout);
-                    nc_addtimespec(&ts_timeout, timeout);
+                    nc_gettimespec_mono_add(&ts_timeout, timeout);
                 }
             }
             break;
@@ -1373,16 +1355,12 @@ connect_ssh_session(struct nc_session *session, struct nc_client_ssh_opts *opts,
                 }
 
                 if (timeout > -1) {
-                    nc_gettimespec_mono(&ts_timeout);
-                    nc_addtimespec(&ts_timeout, timeout);
+                    nc_gettimespec_mono_add(&ts_timeout, timeout);
                 }
                 while ((ret_auth = ssh_userauth_try_publickey(ssh_sess, NULL, pubkey)) == SSH_AUTH_AGAIN) {
                     usleep(NC_TIMEOUT_STEP);
-                    if (timeout > -1) {
-                        nc_gettimespec_mono(&ts_cur);
-                        if (nc_difftimespec(&ts_cur, &ts_timeout) < 1) {
-                            break;
-                        }
+                    if ((timeout > -1) && (nc_difftimespec_cur(&ts_timeout) < 1)) {
+                        break;
                     }
                 }
                 ssh_key_free(pubkey);
@@ -1413,16 +1391,12 @@ connect_ssh_session(struct nc_session *session, struct nc_client_ssh_opts *opts,
                 }
 
                 if (timeout > -1) {
-                    nc_gettimespec_mono(&ts_timeout);
-                    nc_addtimespec(&ts_timeout, timeout);
+                    nc_gettimespec_mono_add(&ts_timeout, timeout);
                 }
                 while ((ret_auth = ssh_userauth_publickey(ssh_sess, NULL, privkey)) == SSH_AUTH_AGAIN) {
                     usleep(NC_TIMEOUT_STEP);
-                    if (timeout > -1) {
-                        nc_gettimespec_mono(&ts_cur);
-                        if (nc_difftimespec(&ts_cur, &ts_timeout) < 1) {
-                            break;
-                        }
+                    if ((timeout > -1) && (nc_difftimespec_cur(&ts_timeout) < 1)) {
+                        break;
                     }
                 }
                 ssh_key_free(privkey);
@@ -1469,7 +1443,7 @@ open_netconf_channel(struct nc_session *session, int timeout)
 {
     ssh_session ssh_sess;
     int ret;
-    struct timespec ts_timeout, ts_cur;
+    struct timespec ts_timeout;
 
     ssh_sess = session->ti.libssh.session;
 
@@ -1485,17 +1459,13 @@ open_netconf_channel(struct nc_session *session, int timeout)
 
     /* open a channel */
     if (timeout > -1) {
-        nc_gettimespec_mono(&ts_timeout);
-        nc_addtimespec(&ts_timeout, timeout);
+        nc_gettimespec_mono_add(&ts_timeout, timeout);
     }
     session->ti.libssh.channel = ssh_channel_new(ssh_sess);
     while ((ret = ssh_channel_open_session(session->ti.libssh.channel)) == SSH_AGAIN) {
         usleep(NC_TIMEOUT_STEP);
-        if (timeout > -1) {
-            nc_gettimespec_mono(&ts_cur);
-            if (nc_difftimespec(&ts_cur, &ts_timeout) < 1) {
-                break;
-            }
+        if ((timeout > -1) && (nc_difftimespec_cur(&ts_timeout) < 1)) {
+            break;
         }
     }
     if (ret == SSH_AGAIN) {
@@ -1512,16 +1482,12 @@ open_netconf_channel(struct nc_session *session, int timeout)
 
     /* execute the NETCONF subsystem on the channel */
     if (timeout > -1) {
-        nc_gettimespec_mono(&ts_timeout);
-        nc_addtimespec(&ts_timeout, timeout);
+        nc_gettimespec_mono_add(&ts_timeout, timeout);
     }
     while ((ret = ssh_channel_request_subsystem(session->ti.libssh.channel, "netconf")) == SSH_AGAIN) {
         usleep(NC_TIMEOUT_STEP);
-        if (timeout > -1) {
-            nc_gettimespec_mono(&ts_cur);
-            if (nc_difftimespec(&ts_cur, &ts_timeout) < 1) {
-                break;
-            }
+        if ((timeout > -1) && (nc_difftimespec_cur(&ts_timeout) < 1)) {
+            break;
         }
     }
     if (ret == SSH_AGAIN) {

--- a/src/session_p.h
+++ b/src/session_p.h
@@ -520,13 +520,33 @@ struct passwd *nc_getpwuid(uid_t uid, struct passwd *pwd_buf, char **buf, size_t
 
 NC_MSG_TYPE nc_send_msg_io(struct nc_session *session, int io_timeout, struct lyd_node *op);
 
-int nc_gettimespec_mono(struct timespec *ts);
+/**
+ * @brief Get the current real time if available and optionally add some time to it.
+ *
+ * @param[in,out] ts Timespec structure holding time.
+ * @param[in] msec Time in milliseconds to be added.
+ * @return 0 on success;
+ * @return -1 on error.
+ */
+int nc_gettimespec_real_add(struct timespec *ts, uint32_t msec);
 
-int nc_gettimespec_real(struct timespec *ts);
+/**
+ * @brief Get the current monotonic time if available and optionally add some time to it.
+ *
+ * @param[in,out] ts Timespec structure holding time.
+ * @param[in] msec Time in milliseconds to be added.
+ * @return 0 on success;
+ * @return -1 on error.
+ */
+int nc_gettimespec_mono_add(struct timespec *ts, uint32_t msec);
 
-int32_t nc_difftimespec(const struct timespec *ts1, const struct timespec *ts2);
-
-void nc_addtimespec(struct timespec *ts, uint32_t msec);
+/**
+ * @brief Get time difference based on the current time.
+ *
+ * @param[in] ts Timespec structure holding time from which the current time is going to be subtracted.
+ * @return Time difference in milliseconds.
+ */
+int32_t nc_difftimespec_cur(const struct timespec *ts);
 
 const char *nc_keytype2str(NC_SSH_KEY_TYPE type);
 

--- a/src/session_p.h
+++ b/src/session_p.h
@@ -195,6 +195,8 @@ struct nc_server_opts {
     int (*interactive_auth_clb)(const struct nc_session *session, ssh_message msg, void *user_data);
     void *interactive_auth_data;
     void (*interactive_auth_data_free)(void *data);
+    char *conf_name;
+    char *conf_dir;
 #endif
 #ifdef NC_ENABLED_TLS
     int (*user_verify_clb)(const struct nc_session *session);
@@ -513,6 +515,18 @@ struct nc_ntf_thread_arg {
     struct nc_session *session;
     void (*notif_clb)(struct nc_session *session, const struct lyd_node *envp, const struct lyd_node *op);
 };
+
+#ifdef NC_ENABLED_SSH
+
+/**
+ * @brief PAM callback arguments.
+ */
+struct nc_pam_thread_arg {
+    ssh_message msg;            /**< libssh message */
+    struct nc_session *session; /**< NETCONF session */
+};
+
+#endif
 
 void *nc_realloc(void *ptr, size_t size);
 

--- a/src/session_server.c
+++ b/src/session_server.c
@@ -776,6 +776,12 @@ nc_server_destroy(void)
     }
     server_opts.hostkey_data = NULL;
     server_opts.hostkey_data_free = NULL;
+
+    /* PAM */
+    free(server_opts.conf_name);
+    free(server_opts.conf_dir);
+    server_opts.conf_name = NULL;
+    server_opts.conf_dir = NULL;
 #endif
 #ifdef NC_ENABLED_TLS
     if (server_opts.server_cert_data && server_opts.server_cert_data_free) {
@@ -1995,7 +2001,7 @@ nc_server_add_endpt(const char *name, NC_TRANSPORT_IMPL ti)
             goto cleanup;
         }
         server_opts.endpts[server_opts.endpt_count - 1].opts.ssh->auth_methods =
-                NC_SSH_AUTH_PUBLICKEY | NC_SSH_AUTH_PASSWORD | NC_SSH_AUTH_INTERACTIVE;
+                NC_SSH_AUTH_PUBLICKEY | NC_SSH_AUTH_PASSWORD;
         server_opts.endpts[server_opts.endpt_count - 1].opts.ssh->auth_attempts = 3;
         server_opts.endpts[server_opts.endpt_count - 1].opts.ssh->auth_timeout = 30;
         break;
@@ -2817,7 +2823,7 @@ nc_server_ch_client_add_endpt(const char *client_name, const char *endpt_name, N
             ERRMEM;
             goto cleanup;
         }
-        endpt->opts.ssh->auth_methods = NC_SSH_AUTH_PUBLICKEY | NC_SSH_AUTH_PASSWORD | NC_SSH_AUTH_INTERACTIVE;
+        endpt->opts.ssh->auth_methods = NC_SSH_AUTH_PUBLICKEY | NC_SSH_AUTH_PASSWORD;
         endpt->opts.ssh->auth_attempts = 3;
         endpt->opts.ssh->auth_timeout = 30;
         break;

--- a/src/session_server.c
+++ b/src/session_server.c
@@ -934,9 +934,9 @@ nc_accept_inout(int fdin, int fdout, const char *username, const struct ly_ctx *
         return msgtype;
     }
 
-    nc_gettimespec_mono(&ts_cur);
+    nc_gettimespec_mono_add(&ts_cur, 0);
     (*session)->opts.server.last_rpc = ts_cur.tv_sec;
-    nc_gettimespec_real(&ts_cur);
+    nc_gettimespec_real_add(&ts_cur, 0);
     (*session)->opts.server.session_start = ts_cur.tv_sec;
 
     (*session)->status = NC_STATUS_RUNNING;
@@ -1014,8 +1014,7 @@ nc_ps_lock(struct nc_pollsession *ps, uint8_t *id, const char *func)
     int ret;
     struct timespec ts;
 
-    nc_gettimespec_real(&ts);
-    nc_addtimespec(&ts, NC_PS_LOCK_TIMEOUT);
+    nc_gettimespec_real_add(&ts, NC_PS_LOCK_TIMEOUT);
 
     /* LOCK */
     ret = pthread_mutex_timedlock(&ps->lock, &ts);
@@ -1038,8 +1037,7 @@ nc_ps_lock(struct nc_pollsession *ps, uint8_t *id, const char *func)
 
     /* is it our turn? */
     while (ps->queue[ps->queue_begin] != *id) {
-        nc_gettimespec_real(&ts);
-        nc_addtimespec(&ts, NC_PS_QUEUE_TIMEOUT);
+        nc_gettimespec_real_add(&ts, NC_PS_QUEUE_TIMEOUT);
 
         ret = pthread_cond_timedwait(&ps->cond, &ps->lock, &ts);
         if (ret) {
@@ -1072,8 +1070,7 @@ nc_ps_unlock(struct nc_pollsession *ps, uint8_t id, const char *func)
     int ret;
     struct timespec ts;
 
-    nc_gettimespec_real(&ts);
-    nc_addtimespec(&ts, NC_PS_LOCK_TIMEOUT);
+    nc_gettimespec_real_add(&ts, NC_PS_LOCK_TIMEOUT);
 
     /* LOCK */
     ret = pthread_mutex_timedlock(&ps->lock, &ts);
@@ -1672,10 +1669,9 @@ nc_ps_poll(struct nc_pollsession *ps, int timeout, struct nc_session **session)
     }
 
     /* fill timespecs */
-    nc_gettimespec_mono(&ts_cur);
+    nc_gettimespec_mono_add(&ts_cur, 0);
     if (timeout > -1) {
-        nc_gettimespec_mono(&ts_timeout);
-        nc_addtimespec(&ts_timeout, timeout);
+        nc_gettimespec_mono_add(&ts_timeout, timeout);
     }
 
     /* poll all the sessions one-by-one */
@@ -1768,10 +1764,8 @@ nc_ps_poll(struct nc_pollsession *ps, int timeout, struct nc_session **session)
         /* no event, no session remains locked */
         if (ret == NC_PSPOLL_TIMEOUT) {
             usleep(NC_TIMEOUT_STEP);
-            /* update current time */
-            nc_gettimespec_mono(&ts_cur);
 
-            if ((timeout > -1) && (nc_difftimespec(&ts_cur, &ts_timeout) < 1)) {
+            if ((timeout > -1) && (nc_difftimespec_cur(&ts_timeout) < 1)) {
                 /* final timeout */
                 break;
             }
@@ -2527,9 +2521,9 @@ nc_accept(int timeout, const struct ly_ctx *ctx, struct nc_session **session)
         return msgtype;
     }
 
-    nc_gettimespec_mono(&ts_cur);
+    nc_gettimespec_mono_add(&ts_cur, 0);
     (*session)->opts.server.last_rpc = ts_cur.tv_sec;
-    nc_gettimespec_real(&ts_cur);
+    nc_gettimespec_real_add(&ts_cur, 0);
     (*session)->opts.server.session_start = ts_cur.tv_sec;
     (*session)->status = NC_STATUS_RUNNING;
 
@@ -3331,9 +3325,9 @@ nc_connect_ch_endpt(struct nc_ch_endpt *endpt, nc_server_ch_session_acquire_ctx_
         goto fail;
     }
 
-    nc_gettimespec_mono(&ts_cur);
+    nc_gettimespec_mono_add(&ts_cur, 0);
     (*session)->opts.server.last_rpc = ts_cur.tv_sec;
-    nc_gettimespec_real(&ts_cur);
+    nc_gettimespec_real_add(&ts_cur, 0);
     (*session)->opts.server.session_start = ts_cur.tv_sec;
     (*session)->status = NC_STATUS_RUNNING;
 
@@ -3409,8 +3403,7 @@ nc_server_ch_client_thread_session_cond_wait(struct nc_session *session, struct 
     }
 
     do {
-        nc_gettimespec_real(&ts);
-        nc_addtimespec(&ts, NC_CH_NO_ENDPT_WAIT);
+        nc_gettimespec_real_add(&ts, NC_CH_NO_ENDPT_WAIT);
 
         /* CH COND WAIT */
         r = pthread_cond_timedwait(&session->opts.server.ch_cond, &session->opts.server.ch_lock, &ts);
@@ -3442,7 +3435,7 @@ nc_server_ch_client_thread_session_cond_wait(struct nc_session *session, struct 
             idle_timeout = 0;
         }
 
-        nc_gettimespec_mono(&ts);
+        nc_gettimespec_mono_add(&ts, 0);
         if (!nc_session_get_notif_status(session) && idle_timeout && (ts.tv_sec >= session->opts.server.last_rpc + idle_timeout)) {
             VRB(session, "Call Home client \"%s\": session idle timeout elapsed.", client->name);
             session->status = NC_STATUS_INVALID;

--- a/src/session_server.h
+++ b/src/session_server.h
@@ -580,18 +580,32 @@ void nc_server_ssh_set_passwd_auth_clb(int (*passwd_auth_clb)(const struct nc_se
  *
  * @param[in] interactive_auth_clb Callback that should authenticate the user.
  * Zero return indicates success, non-zero an error.
- * @param[in] user_data Optional arbitrary user data that will be passed to @p passwd_auth_clb.
+ * @param[in] user_data Optional arbitrary user data that will be passed to @p interactive_auth_clb.
  * @param[in] free_user_data Optional callback that will be called during cleanup to free any @p user_data.
  */
 void nc_server_ssh_set_interactive_auth_clb(int (*interactive_auth_clb)(const struct nc_session *session,
         const ssh_message msg, void *user_data), void *user_data, void (*free_user_data)(void *user_data));
 
 /**
+ * @brief Set the name and a path to a PAM configuration file.
+ *
+ * @p conf_name has to be set via this function prior to using keyboard-interactive authentication method.
+ *
+ * @param[in] conf_name Name of the configuration file.
+ * @param[in] conf_dir Optional. The absolute path to the directory in which the configuration file
+ * with the name @p conf_name is located. A newer version (>= 1.4) of PAM library is required to be
+ * able to specify the path. If NULL is passed,
+ * then the PAM's system directories will be searched (usually /etc/pam.d/).
+ * @return 0 on success, -1 on error.
+ */
+int nc_server_ssh_set_pam_conf_path(const char *conf_name, const char *conf_dir);
+
+/**
  * @brief Set the callback for SSH public key authentication. If none is set, local system users are used.
  *
  * @param[in] pubkey_auth_clb Callback that should authenticate the user.
  * Zero return indicates success, non-zero an error.
- * @param[in] user_data Optional arbitrary user data that will be passed to @p passwd_auth_clb.
+ * @param[in] user_data Optional arbitrary user data that will be passed to @p pubkey_auth_clb.
  * @param[in] free_user_data Optional callback that will be called during cleanup to free any @p user_data.
  */
 void nc_server_ssh_set_pubkey_auth_clb(int (*pubkey_auth_clb)(const struct nc_session *session, ssh_key key,
@@ -642,7 +656,7 @@ int nc_server_ssh_endpt_del_hostkey(const char *endpt_name, const char *name, in
  * @param[in] endpt_name Exisitng endpoint name.
  * @param[in] key_mov Name of the host key that will be moved.
  * @param[in] key_after Name of the key that will preceed @p key_mov. NULL if @p key_mov is to be moved at the beginning.
- * @return 0 in success, -1 on error.
+ * @return 0 on success, -1 on error.
  */
 int nc_server_ssh_endpt_mov_hostkey(const char *endpt_name, const char *key_mov, const char *key_after);
 
@@ -652,7 +666,7 @@ int nc_server_ssh_endpt_mov_hostkey(const char *endpt_name, const char *key_mov,
  * @param[in] endpt_name Exisitng endpoint name.
  * @param[in] name Name of an existing host key.
  * @param[in] new_name New name of the host key @p name.
- * @return 0 in success, -1 on error.
+ * @return 0 on success, -1 on error.
  */
 int nc_server_ssh_endpt_mod_hostkey(const char *endpt_name, const char *name, const char *new_name);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,12 +3,18 @@ add_test(NAME headers
     COMMAND ${CMAKE_SOURCE_DIR}/compat/check_includes.sh ${CMAKE_SOURCE_DIR}/src/)
 
 # format
-if (${SOURCE_FORMAT_ENABLED})
+if(${SOURCE_FORMAT_ENABLED})
     add_test(NAME format WORKING_DIRECTORY ${CMAKE_BINARY_DIR} COMMAND cmake --build ${CMAKE_BINARY_DIR} --target format-check)
 endif()
 
 # list of all the tests in each directory
 set(tests test_io test_fd_comm test_init_destroy_client test_init_destroy_server test_client_thread test_thread_messages)
+
+# only enable PAM tests if the version of PAM is greater than 1.4
+if(LIBPAM_HAVE_CONFDIR)
+    list(APPEND tests test_pam)
+endif()
+
 set(client_tests test_client test_client_messages)
 
 # add -Wl,--wrap flags
@@ -76,3 +82,20 @@ endif()
 
 include_directories(${CMAKE_SOURCE_DIR}/src ${PROJECT_BINARY_DIR})
 configure_file("${PROJECT_SOURCE_DIR}/tests/config.h.in" "${PROJECT_BINARY_DIR}/tests/config.h" ESCAPE_QUOTES @ONLY)
+
+if(LIBPAM_HAVE_CONFDIR)
+
+    #compile PAM test module
+    add_library(pam_netconf SHARED ${CMAKE_SOURCE_DIR}/tests/pam/pam_netconf.c)
+    set_target_properties(pam_netconf PROPERTIES PREFIX "")
+    target_link_libraries(pam_netconf ${LIBPAM_LIBRARIES})
+
+    #generate PAM configuration file
+    file(WRITE ${CMAKE_SOURCE_DIR}/tests/pam/netconf.conf
+        "#%PAM-1.4\n"
+        "auth required ${CMAKE_SOURCE_DIR}/build/tests/pam_netconf.so\n"
+        "account required ${CMAKE_SOURCE_DIR}/build/tests/pam_netconf.so\n"
+        "password required ${CMAKE_SOURCE_DIR}/build/tests/pam_netconf.so\n"
+    )
+
+endif()

--- a/tests/client/test_client_ssh.c
+++ b/tests/client/test_client_ssh.c
@@ -447,11 +447,11 @@ test_nc_client_ssh_setting_auth_pref(void **state)
 
     /* check default prefference settings according to documentation */
     ret = nc_client_ssh_get_auth_pref(NC_SSH_AUTH_INTERACTIVE);
-    assert_int_equal(ret, 3);
+    assert_int_equal(ret, 1);
     ret = nc_client_ssh_get_auth_pref(NC_SSH_AUTH_PASSWORD);
     assert_int_equal(ret, 2);
     ret = nc_client_ssh_get_auth_pref(NC_SSH_AUTH_PUBLICKEY);
-    assert_int_equal(ret, 1);
+    assert_int_equal(ret, 3);
 
     /* try to set prefetence of non existing method */
     nc_client_ssh_set_auth_pref(42, 22);

--- a/tests/pam/pam_netconf.c
+++ b/tests/pam/pam_netconf.c
@@ -1,0 +1,311 @@
+/**
+ * @file pam_netconf.c
+ * @author Roman Janota <xjanot04@fit.vutbr.cz>
+ * @brief libnetconf2 Linux PAM test module
+ *
+ * @copyright
+ * Copyright (c) 2022 CESNET, z.s.p.o.
+ *
+ * This source code is licensed under BSD 3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#include <security/pam_modules.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "config.h"
+
+#define N_MESSAGES 2
+#define N_REQUESTS 2
+
+/**
+ * @brief Exchange module's messages for user's replies.
+ *
+ * @param[in] pam_h PAM handle.
+ * @param[in] n_messages Number of messages.
+ * @param[in] msg Module's messages for the user.
+ * @param[out] resp User's responses.
+ * @return PAM_SUCCESS on success;
+ * @return PAM error otherwise.
+ */
+static int
+nc_pam_mod_call_clb(pam_handle_t *pam_h, int n_messages, const struct pam_message **msg, struct pam_response **resp)
+{
+    struct pam_conv *conv;
+    int r;
+
+    /* the callback can be accessed through the handle */
+    r = pam_get_item(pam_h, PAM_CONV, (void *) &conv);
+    if (r != PAM_SUCCESS) {
+        return r;
+    }
+    return conv->conv(n_messages, msg, resp, conv->appdata_ptr);
+}
+
+/**
+ * @brief Validate the user's responses.
+ *
+ * @param[in] username Username.
+ * @param[in] reversed_username User's response to the first challenge.
+ * @param[in] eq_ans User's response to the second challenge.
+ * @return PAM_SUCCESS on success;
+ * @return PAM_AUTH_ERR whenever the user's replies are incorrect.
+ */
+static int
+nc_pam_mod_auth(const char *username, char *reversed_username, char *eq_ans)
+{
+    int i, j, r;
+    size_t len;
+    char *buffer;
+
+    len = strlen(reversed_username);
+    buffer = calloc(len + 1, sizeof *buffer);
+    if (!buffer) {
+        fprintf(stderr, "Memory allocation error.\n");
+        return PAM_BUF_ERR;
+    }
+
+    /* reverse the user's response */
+    for (i = len - 1, j = 0; i >= 0; i--) {
+        buffer[j++] = reversed_username[i];
+    }
+    buffer[j] = '\0';
+
+    if (!strcmp(username, buffer) && !strcmp(eq_ans, "2")) {
+        /* it's a match */
+        r = PAM_SUCCESS;
+    } else {
+        r = PAM_AUTH_ERR;
+    }
+
+    free(buffer);
+    return r;
+}
+
+/**
+ * @brief Free the user's responses.
+ *
+ * @param[in] resp Responses.
+ * @param[in] n Number of responses to be freed.
+ */
+static void
+nc_pam_mod_resp_free(struct pam_response *resp, int n)
+{
+    int i;
+
+    if (!resp) {
+        return;
+    }
+
+    for (i = 0; i < n; i++) {
+        free((resp + i)->resp);
+    }
+    free(resp);
+}
+
+/**
+ * @brief Test module's implementation of "auth" service.
+ *
+ * Prepare prompts for the client and decide based on his
+ * answers whether to allow or disallow access.
+ *
+ * @param[in] pam_h PAM handle.
+ * @param[in] flags Flags.
+ * @param[in] argc Count of module options defined in the PAM configuration file.
+ * @param[in] argv Module options.
+ * @return PAM_SUCCESS on success;
+ * @return PAM error otherwise.
+ */
+API int
+pam_sm_authenticate(pam_handle_t *pam_h, int flags, int argc, const char **argv)
+{
+    int r;
+    const char *username;
+    char *reversed_username = NULL, *eq_ans = NULL;
+    struct pam_message echo_msg, no_echo_msg, unexpected_type_msg, info_msg, err_msg;
+    const struct pam_message *msg[N_MESSAGES];
+    struct pam_response *resp = NULL;
+
+    (void) flags;
+    (void) argc;
+    (void) argv;
+
+    /* get the username and if it's not known then the user will be prompted to enter it */
+    r = pam_get_user(pam_h, &username, NULL);
+    if (r != PAM_SUCCESS) {
+        fprintf(stderr, "Unable to get username.\n");
+        r = PAM_AUTHINFO_UNAVAIL;
+        goto cleanup;
+    }
+
+    /* prepare the messages */
+    echo_msg.msg_style = PAM_PROMPT_ECHO_ON;
+    echo_msg.msg = "Enter your username backwards: ";
+    no_echo_msg.msg_style = PAM_PROMPT_ECHO_OFF;
+    no_echo_msg.msg = "Enter the result to 1+1: ";
+    unexpected_type_msg.msg_style = PAM_AUTH_ERR;
+    unexpected_type_msg.msg = "Arbitrary test message";
+    info_msg.msg_style = PAM_TEXT_INFO;
+    info_msg.msg = "Test info message";
+    err_msg.msg_style = PAM_ERROR_MSG;
+    err_msg.msg = "Test error message";
+
+    /* tests */
+    printf("[TEST #1] Too many PAM messages. Output:\n");
+    r = nc_pam_mod_call_clb(pam_h, 500, msg, &resp);
+    if (r == PAM_SUCCESS) {
+        fprintf(stderr, "[TEST #1] Failed.\n");
+        r = PAM_AUTH_ERR;
+        goto cleanup;
+    }
+    printf("[TEST #1] Passed.\n\n");
+
+    printf("[TEST #2] Negative number of PAM messages. Output:\n");
+    r = nc_pam_mod_call_clb(pam_h, -1, msg, &resp);
+    if (r == PAM_SUCCESS) {
+        fprintf(stderr, "[TEST #2] Failed.\n");
+        r = PAM_AUTH_ERR;
+        goto cleanup;
+    }
+    printf("[TEST #2] Passed.\n\n");
+
+    printf("[TEST #3] 0 PAM messages. Output:\n");
+    r = nc_pam_mod_call_clb(pam_h, 0, msg, &resp);
+    if (r == PAM_SUCCESS) {
+        fprintf(stderr, "[TEST #3] Failed.\n");
+        r = PAM_AUTH_ERR;
+        goto cleanup;
+    }
+    printf("[TEST #3] Passed.\n\n");
+
+    printf("[TEST #4] Unexpected message type. Output:\n");
+    msg[0] = &unexpected_type_msg;
+    r = nc_pam_mod_call_clb(pam_h, N_MESSAGES, msg, &resp);
+    if (r == PAM_SUCCESS) {
+        fprintf(stderr, "[TEST #4] Failed.\n");
+        r = PAM_AUTH_ERR;
+        goto cleanup;
+    }
+    printf("[TEST #4] Passed.\n\n");
+
+    printf("[TEST #5] Info and error messages. Output:\n");
+    msg[0] = &info_msg;
+    msg[1] = &err_msg;
+    r = nc_pam_mod_call_clb(pam_h, N_MESSAGES, msg, &resp);
+    if (r == PAM_SUCCESS) {
+        fprintf(stderr, "[TEST #5] Failed.\n");
+        r = PAM_AUTH_ERR;
+        goto cleanup;
+    }
+    printf("[TEST #5] Passed.\n\n");
+
+    printf("[TEST #6] Authentication attempt with an expired token. Output:\n");
+    /* store the correct messages */
+    msg[0] = &echo_msg;
+    msg[1] = &no_echo_msg;
+
+    /* get responses */
+    r = nc_pam_mod_call_clb(pam_h, N_MESSAGES, msg, &resp);
+    if (r != PAM_SUCCESS) {
+        fprintf(stderr, "[TEST #6] Failed.\n");
+        goto cleanup;
+    }
+
+    reversed_username = resp[0].resp;
+    eq_ans = resp[1].resp;
+
+    /* validate the responses */
+    r = nc_pam_mod_auth(username, reversed_username, eq_ans);
+
+    /* not authenticated */
+    if (r != PAM_SUCCESS) {
+        fprintf(stderr, "[TEST #6] Failed.\n");
+        r = PAM_AUTH_ERR;
+    }
+
+cleanup:
+    /* free the responses */
+    nc_pam_mod_resp_free(resp, N_REQUESTS);
+    return r;
+}
+
+/**
+ * @brief Test module's silly implementation of "account" service.
+ *
+ * @param[in] pam_h PAM handle.
+ * @param[in] flags Flags.
+ * @param[in] argc The count of module options defined in the PAM configuration file.
+ * @param[in] argv Module options.
+ * @return PAM_NEW_AUTHTOK_REQD on success;
+ * @return PAM error otherwise.
+ */
+API int
+pam_sm_acct_mgmt(pam_handle_t *pam_h, int flags, int argc, const char *argv[])
+{
+    int r;
+    const void *username;
+
+    (void) flags;
+    (void) argc;
+    (void) argv;
+
+    /* get and check the username */
+    r = pam_get_item(pam_h, PAM_USER, &username);
+    if (r != PAM_SUCCESS) {
+        return r;
+    }
+    if (!strcmp((const char *)username, "test")) {
+        return PAM_NEW_AUTHTOK_REQD;
+    }
+    return PAM_SYSTEM_ERR;
+}
+
+/**
+ * @brief Test module's silly implementation of "password" service.
+ *
+ * @param[in] pam_h PAM handle.
+ * @param[in] flags Flags.
+ * @param[in] argc The count of module options defined in the PAM configuration file.
+ * @param[in] argv Module options.
+ * @return PAM_SUCCESS on success;
+ * @return PAM error otherwise.
+ */
+API int
+pam_sm_chauthtok(pam_handle_t *pam_h, int flags, int argc, const char *argv[])
+{
+    int r;
+    const void *username;
+
+    (void) argc;
+    (void) argv;
+
+    /* the function is called twice, each time with a different flag,
+     * in the first call just check the username if it matches */
+    if (flags & PAM_PRELIM_CHECK) {
+        r = pam_get_item(pam_h, PAM_USER, &username);
+        if (r != PAM_SUCCESS) {
+            return r;
+        }
+        if (!strcmp((const char *)username, "test")) {
+            return PAM_SUCCESS;
+        } else {
+            return PAM_SYSTEM_ERR;
+        }
+
+        /* change the authentication token in the second call */
+    } else if (flags & PAM_UPDATE_AUTHTOK) {
+        r = pam_set_item(pam_h, PAM_AUTHTOK, "test");
+        if (r == PAM_SUCCESS) {
+            printf("[TEST #6] Passed.\n\n");
+        } else {
+            fprintf(stderr, "[TEST #6] Failed.\n");
+        }
+        return r;
+    }
+    return PAM_SYSTEM_ERR;
+}

--- a/tests/test_pam.c
+++ b/tests/test_pam.c
@@ -1,0 +1,189 @@
+/**
+ * @file test_pam.c
+ * @author Roman Janota <xjanot04@fit.vutbr.cz>
+ * @brief libnetconf2 Linux PAM keyboard-interactive authentication test
+ *
+ * @copyright
+ * Copyright (c) 2022 CESNET, z.s.p.o.
+ *
+ * This source code is licensed under BSD 3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <libyang/libyang.h>
+#include <log.h>
+#include <session_client.h>
+#include <session_server.h>
+
+#include "tests/config.h"
+
+#define nc_assert(cond) if (!(cond)) { fprintf(stderr, "assert failed (%s:%d)\n", __FILE__, __LINE__); abort(); }
+
+#define NC_ACCEPT_TIMEOUT 5000
+#define NC_PS_POLL_TIMEOUT 5000
+
+struct ly_ctx *ctx;
+
+static void *
+server_thread(void *arg)
+{
+    int ret;
+    NC_MSG_TYPE msgtype;
+    struct nc_session *session;
+    struct nc_pollsession *ps;
+
+    (void) arg;
+    ps = nc_ps_new();
+    nc_assert(ps);
+
+    /* accept a session and add it to the poll session structure */
+    msgtype = nc_accept(NC_ACCEPT_TIMEOUT, ctx, &session);
+    nc_assert(msgtype == NC_MSG_HELLO);
+    ret = nc_ps_add_session(ps, session);
+    nc_assert(!ret);
+    ret = nc_ps_poll(ps, NC_PS_POLL_TIMEOUT, NULL);
+    nc_assert(ret & NC_PSPOLL_RPC);
+    nc_ps_clear(ps, 0, NULL);
+
+    nc_ps_free(ps);
+    nc_thread_destroy();
+    return NULL;
+}
+
+static int
+clb_hostkeys(const char *name, void *user_data, char **privkey_path, char **privkey_data,
+        NC_SSH_KEY_TYPE *privkey_type)
+{
+    (void) user_data;
+    (void) privkey_data;
+    (void) privkey_type;
+
+    /* set the path to the testing private keys */
+    if (!strcmp(name, "key_rsa")) {
+        *privkey_path = strdup(TESTS_DIR "/data/key_rsa");
+        return 0;
+    } else if (!strcmp(name, "key_dsa")) {
+        *privkey_path = strdup(TESTS_DIR "/data/key_dsa");
+        return 0;
+    }
+
+    return 1;
+}
+
+static char *
+auth_interactive(const char *auth_name, const char *instruction, const char *prompt, int echo, void *priv)
+{
+    (void) instruction;
+    (void) echo;
+    (void) auth_name;
+    (void) priv;
+
+    /* send the replies to keyboard-interactive authentication */
+    if (strstr(prompt, "backwards")) {
+        return strdup("tset");
+    } else if (strstr(prompt, "1+1")) {
+        return strdup("2");
+    } else {
+        return NULL;
+    }
+}
+
+static int
+ssh_hostkey_check_clb(const char *hostname, ssh_session session, void *priv)
+{
+    (void)hostname;
+    (void)session;
+    (void)priv;
+    /* redundant in this test, nonetheless this callback has to be set */
+
+    return 0;
+}
+
+static void *
+client_thread(void *arg)
+{
+    (void) arg;
+    int ret;
+    struct nc_session *session = NULL;
+
+    printf("SSH client started.\n");
+
+    /* initialize client */
+    nc_client_init();
+    ret = nc_client_set_schema_searchpath(TESTS_DIR "/data/modules");
+    nc_assert(!ret);
+    /* skip the knownhost check */
+    nc_client_ssh_set_auth_hostkey_check_clb(ssh_hostkey_check_clb, NULL);
+
+    ret = nc_client_ssh_set_username("test");
+    nc_assert(!ret);
+
+    /* set keyboard-interactive authentication callback */
+    nc_client_ssh_set_auth_interactive_clb(auth_interactive, NULL);
+    session = nc_connect_ssh("0.0.0.0", 6001, NULL);
+    nc_assert(session);
+
+    printf("SSH client finished.\n");
+    nc_client_destroy();
+
+    nc_session_free(session, NULL);
+    nc_thread_destroy();
+    return NULL;
+}
+
+int
+main(void)
+{
+    int ret, i;
+    pthread_t tids[2];
+
+    ly_ctx_new(TESTS_DIR "/data/modules", 0, &ctx);
+    nc_assert(ctx);
+    ly_ctx_load_module(ctx, "ietf-netconf", NULL, NULL);
+
+    nc_verbosity(NC_VERB_VERBOSE);
+    nc_server_init();
+
+    /* set callback */
+    nc_server_ssh_set_hostkey_clb(clb_hostkeys, NULL, NULL);
+
+    /* do first, so that client can connect on SSH */
+    ret = nc_server_add_endpt("main_ssh", NC_TI_LIBSSH);
+    nc_assert(!ret);
+    ret = nc_server_endpt_set_address("main_ssh", "0.0.0.0");
+    nc_assert(!ret);
+    ret = nc_server_endpt_set_port("main_ssh", 6001);
+    nc_assert(!ret);
+    ret = nc_server_ssh_endpt_add_hostkey("main_ssh", "key_rsa", -1);
+    nc_assert(!ret);
+
+    /* in order to use the Linux PAM keyboard-interactive method,
+     * the PAM module has to know where to find the desired configuration file */
+    ret = nc_server_ssh_set_pam_conf_path("netconf.conf", TESTS_DIR "/pam");
+    nc_assert(!ret);
+
+    /* only want to test keyboard-interactive auth method */
+    ret = nc_server_ssh_endpt_set_auth_methods("main_ssh", NC_SSH_AUTH_INTERACTIVE);
+    nc_assert(!ret);
+
+    ret = pthread_create(&tids[0], NULL, client_thread, NULL);
+    nc_assert(!ret);
+    ret = pthread_create(&tids[1], NULL, server_thread, NULL);
+    nc_assert(!ret);
+
+    for (i = 0; i < 2; i++) {
+        pthread_join(tids[i], NULL);
+    }
+
+    nc_server_destroy();
+    ly_ctx_destroy(ctx);
+    return 0;
+}

--- a/tests/test_server_thread.c
+++ b/tests/test_server_thread.c
@@ -149,7 +149,7 @@ ssh_endpt_set_auth_methods_thread(void *arg)
 
     pthread_barrier_wait(&barrier);
 
-    ret = nc_server_ssh_endpt_set_auth_methods("main_ssh", NC_SSH_AUTH_PUBLICKEY | NC_SSH_AUTH_PASSWORD | NC_SSH_AUTH_INTERACTIVE);
+    ret = nc_server_ssh_endpt_set_auth_methods("main_ssh", NC_SSH_AUTH_PUBLICKEY | NC_SSH_AUTH_PASSWORD);
     nc_assert(!ret);
 
     return NULL;


### PR DESCRIPTION
Added the ability to authenticate via Linux PAM when using keyboard-interactive SSH authentication method. With Linux PAM (or Pluggable Authentication Modules for Linux) you are able to create your own type of authentication service by creating a PAM module (a test module is a part of this PR). One new API call was added. Also two new timespec functions were added by merging old ones in order to make some conditions easier to read and less LoC overall.