### PR TITLE
CI: libssh and ASAN/UBSAN updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,11 +121,11 @@ jobs:
             make-target: ""
           }
           - {
-            name: "ASAN and UBSAN",
-            os: "ubuntu-18.04",
+            name: "ASAN and UBSAN, clang14",
+            os: "ubuntu-22.04",
             build-type: "Debug",
             dep-build-type: "Release",
-            cc: "clang",
+            cc: "clang-14",
             options: "-DCMAKE_C_FLAGS=-fsanitize=address,undefined -DENABLE_VALGRIND_TESTS=OFF",
             packages: "",
             snaps: "",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,8 @@ jobs:
             make-target: ""
           }
           - {
-            name: "SSH Only",
-            os: "ubuntu-18.04",
+            name: "SSH Only, upstream libssh, Ubuntu 22.04",
+            os: "ubuntu-22.04",
             build-type: "Debug",
             dep-build-type: "Release",
             cc: "gcc",
@@ -134,7 +134,7 @@ jobs:
           }
           - {
             name: "ABI Check",
-            os: "ubuntu-latest",
+            os: "ubuntu-20.04",
             build-type: "ABICheck",
             dep-build-type: "Debug",
             cc: "gcc",
@@ -148,10 +148,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Deps-packages
+      - name: libssh 0.7 repo
+        if: matrix.config.os == 'ubuntu-18.04' || matrix.config.os == 'ubuntu-20.04'
         shell: bash
         run: |
           sudo add-apt-repository ppa:kedazo/libssh-0.7.x -y
+
+      - name: Deps-packages
+        shell: bash
+        run: |
           sudo apt-get update
           sudo apt-get install $DEFAULT_PACKAGES ${{ matrix.config.packages }}
           if ${{ matrix.config.snaps != '' }}


### PR DESCRIPTION
## CI: stick with libssh-0.7 only on older Ubuntu releases

We cannot stay on the 0.7 branch of libssh indefinitely. The CMake code blacklists 0.9.3 and 0.9.4, which means that Ubuntu 20.04 has to be affected as well, but we can use a modern libssh on a modern Ubuntu just fine.

Since no builds were using Ubuntu 22.04 yet, let's pick one, for example the SSH-only one, and reconfigure that one to use upstream libssh on latest Ubuntu.

## CI: test ASAN/UBSAN with a newer clang
    
There's no point in not using the latest & greatest when it comes to diagnostics. The other builds are still on Ubuntu 18.04 for compatibility reasons, I suppose, but for this one we want to latest fixes from upstream.