### PR TITLE
tests: do not make assumptions about build directory layout

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -93,9 +93,9 @@ if(LIBPAM_HAVE_CONFDIR)
     #generate PAM configuration file
     file(WRITE ${CMAKE_SOURCE_DIR}/tests/pam/netconf.conf
         "#%PAM-1.4\n"
-        "auth required ${CMAKE_SOURCE_DIR}/build/tests/pam_netconf.so\n"
-        "account required ${CMAKE_SOURCE_DIR}/build/tests/pam_netconf.so\n"
-        "password required ${CMAKE_SOURCE_DIR}/build/tests/pam_netconf.so\n"
+        "auth required ${CMAKE_CURRENT_BINARY_DIR}/pam_netconf.so\n"
+        "account required ${CMAKE_CURRENT_BINARY_DIR}/pam_netconf.so\n"
+        "password required ${CMAKE_CURRENT_BINARY_DIR}/pam_netconf.so\n"
     )
 
 endif()


### PR DESCRIPTION
The tests would only work if the build directory was named `build/`, and if it was a subdirectory of the source tree.

Bug: #389
Fixes: 41a11e4 pam UPDATE auth using Linux PAM