### PR TITLE
tests: PAM configuration file now generates in build

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -91,7 +91,7 @@ if(LIBPAM_HAVE_CONFDIR)
     target_link_libraries(pam_netconf ${LIBPAM_LIBRARIES})
 
     #generate PAM configuration file
-    file(WRITE ${CMAKE_SOURCE_DIR}/tests/pam/netconf.conf
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/netconf.conf
         "#%PAM-1.4\n"
         "auth required ${CMAKE_CURRENT_BINARY_DIR}/pam_netconf.so\n"
         "account required ${CMAKE_CURRENT_BINARY_DIR}/pam_netconf.so\n"

--- a/tests/config.h.in
+++ b/tests/config.h.in
@@ -19,6 +19,7 @@
 #endif
 
 #define TESTS_DIR "@CMAKE_SOURCE_DIR@/tests"
+#define BUILD_DIR "@CMAKE_BINARY_DIR@"
 
 @SSH_MACRO@
 @TLS_MACRO@

--- a/tests/test_pam.c
+++ b/tests/test_pam.c
@@ -167,7 +167,7 @@ main(void)
 
     /* in order to use the Linux PAM keyboard-interactive method,
      * the PAM module has to know where to find the desired configuration file */
-    ret = nc_server_ssh_set_pam_conf_path("netconf.conf", TESTS_DIR "/pam");
+    ret = nc_server_ssh_set_pam_conf_path("netconf.conf", BUILD_DIR "/tests");
     nc_assert(!ret);
 
     /* only want to test keyboard-interactive auth method */


### PR DESCRIPTION
Moved the configuration file from `tests/pam/` to `build/tests/` to keep the repository clean and adjusted the pam tests accordingly.