### PR TITLE
Support building a static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ set(TIMEOUT_STEP 100 CACHE STRING "Number of microseconds tasks are repeated unt
 set(YANG_MODULE_DIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}/yang/modules/libnetconf2" CACHE STRING "Directory where to copy the YANG modules to")
 set(CLIENT_SEARCH_DIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}/yang/modules" CACHE STRING "Default NC client YANG module search directory")
 set(CALL_HOME_BACKOFF_WAIT 2 CACHE STRING "Number of seconds to wait between Call Home connection attempts")
+option(BUILD_SHARED_LIBS "By default, shared libs are enabled. Turn off for a static build." ON)
 
 #
 # sources
@@ -210,7 +211,7 @@ endif()
 use_compat()
 
 # netconf2 target
-add_library(netconf2 SHARED ${libsrc} ${compatsrc})
+add_library(netconf2 ${libsrc} ${compatsrc})
 set_target_properties(netconf2 PROPERTIES VERSION ${LIBNETCONF2_SOVERSION_FULL} SOVERSION ${LIBNETCONF2_SOVERSION})
 
 # include repository files with highest priority


### PR DESCRIPTION
This is literally the bare minimum that one has to do in order to let a properly configured CMake do its thing and produce a static library.

*v2: be lazy and rely on CMake's builtin features*

~~I'm deliberately not using CMake's standard way through the `BUILD_SHARED_LIBS` option because the other libraries in the NETCONF/YANG stack already stick to this custom convention.~~