### PR TITLE
server_config BUGFIX remove delete unix endpoint

### DIFF
--- a/src/server_config.c
+++ b/src/server_config.c
@@ -1027,9 +1027,6 @@ nc_server_config_listen(const struct lyd_node *node, NC_OPERATION op)
                 nc_server_config_del_endpt_tls(&server_opts.endpts[i], &server_opts.binds[i]);
                 break;
 #endif /* NC_ENABLED_SSH_TLS */
-            case NC_TI_UNIX:
-                _nc_server_del_endpt_unix_socket(&server_opts.endpts[i], &server_opts.binds[i]);
-                break;
             case NC_TI_NONE:
             case NC_TI_FD:
                 ERRINT;
@@ -1187,9 +1184,6 @@ nc_server_config_endpoint(const struct lyd_node *node, NC_OPERATION op)
                 nc_server_config_del_endpt_tls(endpt, bind);
                 break;
 #endif /* NC_ENABLED_SSH_TLS */
-            case NC_TI_UNIX:
-                _nc_server_del_endpt_unix_socket(endpt, bind);
-                break;
             case NC_TI_NONE:
             case NC_TI_FD:
                 ERRINT;


### PR DESCRIPTION
The unix endpoint can be started with -U option of netopeer2-server. However it is not in the yang config. Leave it when deleting other endpoints.