### PR TITLE
TSAN: don't race through `pthread_cond_destroy`

### DIFF
--- a/src/session_server.c
+++ b/src/session_server.c
@@ -2906,7 +2906,9 @@ cleanup:
     VRB(session, "Call Home client \"%s\" thread exit.", data->client_name);
     free(cur_endpt_name);
     free(data->client_name);
+    pthread_mutex_lock(&data->cond_lock);
     pthread_cond_destroy(&data->cond);
+    pthread_mutex_unlock(&data->cond_lock);
     pthread_mutex_destroy(&data->cond_lock);
     free(data);
     return NULL;


### PR DESCRIPTION
In the `test_ch` test, the `test_nc_ch_tls` case would result in the following report:
```
 WARNING: ThreadSanitizer: data race (pid=7309)
   Write of size 8 at 0x7b24000148e0 by thread T6:
     #0 pthread_cond_destroy <null> (test_ch+0x459fd1) (BuildId: 0dd508005b002d2a874ae63746b8b5ea13e50df5)
     #1 nc_ch_client_thread /home/ci/src/cesnet-gerrit-public/CzechLight/dependencies/libnetconf2/src/session_server.c:2909:5 (test_ch+0x4f9f85) (BuildId: 0dd508005b002d2a874ae63746b8b5ea13e50df5)

   Previous read of size 8 at 0x7b24000148e0 by thread T5 (mutexes: write M0, write M1):
     #0 pthread_cond_signal <null> (test_ch+0x459c6c) (BuildId: 0dd508005b002d2a874ae63746b8b5ea13e50df5)
     #1 nc_server_config_destroy_ch_client /home/ci/src/cesnet-gerrit-public/CzechLight/dependencies/libnetconf2/src/server_config.c:920:9 (test_ch+0x4fb12a) (BuildId: 0dd508005b002d2a874ae63746b8b5ea13e50df5)
     #2 nc_server_config_ch /home/ci/src/cesnet-gerrit-public/CzechLight/dependencies/libnetconf2/src/server_config.c:1039:9 (test_ch+0x4fdd27) (BuildId: 0dd508005b002d2a874ae63746b8b5ea13e50df5)
     #3 nc_server_config_setup_data /home/ci/src/cesnet-gerrit-public/CzechLight/dependencies/libnetconf2/src/server_config.c:4211:5 (test_ch+0x4fdd27)
     #4 server_thread_tls /home/ci/src/cesnet-gerrit-public/CzechLight/dependencies/libnetconf2/tests/test_ch.c:307:11 (test_ch+0x522849) (BuildId: 0dd508005b002d2a874ae63746b8b5ea13e50df5)
```
The [`pthread_cond_destroy(3p)`](https://linux.die.net/man/3/pthread_cond_destroy) documentation says that:

> It shall be safe to destroy an initialized condition variable upon which no threads are currently blocked. Attempting to destroy a condition variable upon which other threads are currently blocked results in undefined behavior.

Let's make sure that this is the case by locking the associated mutex.