### PR TITLE
clean up log callbacks

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -123,18 +123,8 @@ prv_printf(const struct nc_session *session, NC_VERB_LEVEL level, const char *fo
     va_end(ap);
 }
 
-static void
-nc_ly_log_clb(LY_LOG_LEVEL lvl, const char *msg, const char *UNUSED(data_path), const char *UNUSED(schema_path),
-        uint64_t UNUSED(line))
-{
-    if (print_clb) {
-        print_clb(NULL, (NC_VERB_LEVEL)lvl, msg);
-    }
-}
-
 API void
 nc_set_print_clb_session(void (*clb)(const struct nc_session *, NC_VERB_LEVEL, const char *))
 {
     print_clb = clb;
-    ly_set_log_clb(nc_ly_log_clb);
 }

--- a/src/log.c
+++ b/src/log.c
@@ -35,7 +35,6 @@
  */
 ATOMIC_T verbose_level = 0;
 
-void (*depr_print_clb)(NC_VERB_LEVEL level, const char *msg);
 void (*print_clb)(const struct nc_session *session, NC_VERB_LEVEL level, const char *msg);
 
 API void
@@ -103,8 +102,6 @@ prv_vprintf(const struct nc_session *session, NC_VERB_LEVEL level, const char *f
 
     if (print_clb) {
         print_clb(session, level, prv_msg);
-    } else if (depr_print_clb) {
-        depr_print_clb(level, prv_msg);
     } else if (session && session->id) {
         fprintf(stderr, "Session %u %s: %s\n", session->id, verb[level].label, prv_msg);
     } else {
@@ -132,8 +129,6 @@ nc_ly_log_clb(LY_LOG_LEVEL lvl, const char *msg, const char *UNUSED(data_path), 
 {
     if (print_clb) {
         print_clb(NULL, (NC_VERB_LEVEL)lvl, msg);
-    } else if (depr_print_clb) {
-        depr_print_clb((NC_VERB_LEVEL)lvl, msg);
     }
 }
 
@@ -141,6 +136,5 @@ API void
 nc_set_print_clb_session(void (*clb)(const struct nc_session *, NC_VERB_LEVEL, const char *))
 {
     print_clb = clb;
-    depr_print_clb = NULL;
     ly_set_log_clb(nc_ly_log_clb);
 }

--- a/src/log.h
+++ b/src/log.h
@@ -74,8 +74,6 @@ void nc_libssh_thread_verbosity(int level);
 /**
  * @brief Set libnetconf print callback.
  *
- * This callback is set for libnetconf2 and also libyang that is used internally. libyang
- * callback can be set explicitly, but must be done so after calling this function.
  * The callback is not set per-session, it is a global resource. It might be called with
  * a NULL session parameter.
  *

--- a/src/log.h
+++ b/src/log.h
@@ -76,6 +76,8 @@ void nc_libssh_thread_verbosity(int level);
  *
  * This callback is set for libnetconf2 and also libyang that is used internally. libyang
  * callback can be set explicitly, but must be done so after calling this function.
+ * The callback is not set per-session, it is a global resource. It might be called with
+ * a NULL session parameter.
  *
  * @param[in] clb Callback that is called for every message.
  */


### PR DESCRIPTION
Fix for #476 by:

- cleaning up some dead code in the first commit,
- improving the docs in the second commit,
- removal of setting the libyang logger in the third commit

You might not like the third commit, so feel free to cherry-pick what makes sense to you. I obviously still think that it's a bad idea to override a logger of another library like this, but in the end it's your call.