### PR TITLE
Support SSH authentication for non-configured users

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,3 +247,38 @@ Tests can be run by the make's `test` target:
 $ make test
 ```
 
+## Supported YANG modules
+
+### Server
+
+The *libnetconf2* NETCONF server has two APIs that load YANG modules into the context. The first API is [nc_server_init_ctx](https://netopeer.liberouter.org/doc/libnetconf2/master/html/group__server__functions.html#ga35cccf2dbe9204abe01ccb4b93db7438), which loads the following YANG modules with their features:
+
+- **ietf-netconf**: writable-running, candidate, rollback-on-error, validate, startup, url, xpath, confirmed-commit,
+- **ietf-netconf-monitoring**: no features.
+
+The second API is [nc_server_config_load_modules](https://netopeer.liberouter.org/doc/libnetconf2/master/html/group__server__config__functions.html#ga3760b87e3ab4309514e9ad82c4c09cdb). Supported features (marked by ✔) are loaded into the context by this API. The only exception is the feature `local-users-supported`, which is by default loaded, but can be disabled, which will influence the behaviour of the SSH authentication (see the *libnetconf2* [documentation](https://netopeer.liberouter.org/doc/libnetconf2/master/html/howtoserver.html)).
+
+- **iana-crypt-hash**: crypt-hash-md5 ✔, crypt-hash-sha-256 ✔, crypt-hash-sha-512 ✔,
+- **ietf-netconf-server**: ssh-listen ✔, tls-listen ✔, ssh-call-home ✔, tls-call-home ✔, central-netconf-server-supported ✔,
+- **iana-ssh-encryption-algs**: no features,
+- **iana-ssh-key-exchange-algs**: no features,
+- **iana-ssh-mac-algs**: no features,
+- **iana-ssh-public-key-algs**: no features,
+- **iana-tls-cipher-suite-algs**: no features,
+- **ietf-crypto-types**: cleartext-passwords ✔, cleartext-private-keys ✔, private-key-encryption ✘, csr-generation ✘, p10-csr-format ✘, certificate-expiration-notification ✘, encrypted-passwords ✘, hidden-symmetric-keys ✘, encrypted-symmetric-keys ✘, hidden-private-keys ✘, encrypted-private-keys ✘, one-symmetric-key-format ✘, one-asymmetric-key-format ✘, symmetrically-encrypted-value-format ✘, asymmetrically-encrypted-value-format ✘, cms-enveloped-data-format ✘, cms-encrypted-data-format ✘, cleartext-symmetric-keys ✘,
+- **ietf-keystore**: central-keystore-supported ✔, inline-definitions-supported ✔, asymmetric-keys ✔, symmetric-keys ✘,
+- **ietf-netconf-server**: ssh-listen ✔, tls-listen ✔, ssh-call-home ✔, tls-call-home ✔, central-netconf-server-supported ✔,
+- **ietf-ssh-common**: transport-params ✔, ssh-x509-certs ✘, public-key-generation ✘,
+- **ietf-ssh-server**: local-users-supported **?**, local-user-auth-publickey ✔, local-user-auth-password ✔, local-user-auth-none ✔, ssh-server-keepalives ✘, local-user-auth-hostbased ✘,
+- **ietf-tcp-client**: tcp-client-keepalives ✔, proxy-connect ✘, socks5-gss-api ✘, socks5-username-password ✘, local-binding-supported ✘,
+- **ietf-tcp-common**: transport-params ✔, ssh-x509-certs ✘, public-key-generation ✘,
+- **ietf-tcp-server**: tcp-server-keepalives ✔,
+- **ietf-tls-common**: tls10 ✔, tls11 ✔, tls12 ✔, tls13 ✔, hello-params ✔, public-key-generation ✘,
+- **ietf-tls-server**: server-ident-x509-cert ✔, client-auth-supported ✔, client-auth-x509-cert ✔, tls-server-keepalives ✘, server-ident-raw-public-key ✘, server-ident-tls12-psk ✘, server-ident-tls13-epsk ✘, client-auth-raw-public-key ✘, client-auth-tls12-psk ✘, client-auth-tls13-epsk ✘,
+- **ietf-truststore**: central-truststore-supported ✔, inline-definitions-supported ✔, certificates ✔, public-keys ✔,
+- **ietf-x509-cert-to-name**: no features,
+- **libnetconf2-netconf-server**: no features.
+
+### Client
+
+Currently no client specific YANG modules are supported.

--- a/doc/libnetconf.doc
+++ b/doc/libnetconf.doc
@@ -386,10 +386,16 @@
  * To successfully accept an SSH session you must configure at least one host key.
  * You may create this data yourself or by using ::nc_server_config_add_ssh_hostkey().
  *
- * On top of that, each SSH endpoint can define it's own authorized clients and their authentication methods.
+ * It is important to decide whether the users that can connect to the SSH server should be obtained from the configuration or from the system.
+ * If the YANG feature *local-users-supported* is enabled (the default), then the authorized users are derived from the configuration. 
+ * When a client connects to the server, he must be found in the configuration and he must authenticate to **all** of his configured authentication methods.
+ * If the feature is disabled, then the system will be used to try to authenticate the client via one of the three
+ * methods - publickey, keyboard-interactive or password (only one of them has to succeed).
+ *
+ * If the local users are supported then each SSH endpoint can define it's own authorized clients and their authentication methods.
  * For example if you wish to create an SSH user that can authenticate using a password, use ::nc_server_config_add_ssh_user_password().
  * Another option for authorized clients is to reference another endpoint's clients, however be careful not to create a cyclic reference
- * (see ::nc_server_config_add_ssh_endpoint_client_ref()). An authorized client MUST authenticate to all of it's configured authentication methods.
+ * (see ::nc_server_config_add_ssh_endpoint_client_ref()).
  *
  * \anchor ln2doc_pubkey
  * The Public Key authentication method is supported. If you wish to use this method, you need to specify the given user's
@@ -398,7 +404,8 @@
  * in the ietf-trustore module's YANG data and then reference them (truststore-reference). The final option is to set the global
  * path to file with public keys. This path may contain special tokens, see ::nc_server_ssh_set_authkey_path_format().
  * If the path is set and the use-system-keys container is present in the data for the client wishing to authenticate,
- * then the keys from the file will be used for authentication.
+ * then the keys from the file will be used for authentication. If the YANG feature *local-users-supported* is disabled,
+ * then it's neccessary to set the path format using ::nc_server_ssh_set_authkey_path_format().
  *
  * \anchor ln2doc_kbdint
  * The Keyboard Interactive authentication method is also supported. It can be done in three ways.

--- a/src/server_config.h
+++ b/src/server_config.h
@@ -60,6 +60,10 @@ extern "C" {
  * iana-ssh-mac-algs, iana-ssh-public-key-algs, ietf-keystore, ietf-ssh-server, ietf-truststore,
  * ietf-tls-server and libnetconf2-netconf-server.
  *
+ * Note that the SSH authentication depends on the value of the 'local-users-supported' feature in the ietf-ssh-server module.
+ * If the feature, and its dependent if-features, are disabled, the SSH authentication will use the system users.
+ * Otherwise, the SSH authentication will use the local users from the configuration (the default).
+ *
  * @param[in, out] ctx Optional context in which the modules will be implemented. Created if *ctx is null.
  * @return 0 on success, 1 on error.
  */

--- a/src/session_server_ssh.c
+++ b/src/session_server_ssh.c
@@ -529,6 +529,7 @@ nc_server_ssh_getspnam(const char *username, struct spwd *spwd_buf, char **buf, 
         r = getspnam_r(username, spwd_buf, *buf, *buf_size, &spwd);
 # else
         spwd = getspnam_r(username, spwd_buf, *buf, *buf_size);
+        r = errno;
 # endif
         if (spwd) {
             /* entry found */

--- a/src/session_server_ssh.c
+++ b/src/session_server_ssh.c
@@ -284,6 +284,11 @@ nc_server_ssh_get_system_keys_path(const char *username, char **out_path)
     struct passwd *pw, pw_buf;
     size_t buf_len = 0;
 
+    if (!path_fmt) {
+        ERR(NULL, "System public keys path format not set.");
+        return 1;
+    }
+
     /* check if the path format contains any tokens */
     if (strstr(path_fmt, "%h") || strstr(path_fmt, "%U") || strstr(path_fmt, "%u") || strstr(path_fmt, "%%")) {
         /* get pw */


### PR DESCRIPTION
Based on the value of the YANG feature `local-users-supported` the SSH server decides, whether to lookup authorized users from the configuration or from the system.

Resolves #486 