### PR TITLE
CTN: obtain client's username from both CA certs and the client cert

### DIFF
--- a/src/session_openssl.c
+++ b/src/session_openssl.c
@@ -309,6 +309,19 @@ nc_server_tls_verify_cb(int preverify_ok, X509_STORE_CTX *x509_ctx)
         return 0;
     }
     data = SSL_CTX_get_ex_data(ctx, 0);
+    if (!data) {
+        ERRINT;
+        return 0;
+    }
+
+    /* get the cert chain once */
+    if (!data->chain) {
+        data->chain = X509_STORE_CTX_get0_chain(x509_ctx);
+        if (!data->chain) {
+            ERRINT;
+            return 0;
+        }
+    }
 
     /* get current cert and its depth */
     cert = X509_STORE_CTX_get_current_cert(x509_ctx);
@@ -471,6 +484,18 @@ nc_tls_get_san_value_type_wrap(void *sans, int idx, char **san_value, NC_TLS_CTN
     }
 
     return ret;
+}
+
+int
+nc_tls_get_num_certs_wrap(void *chain)
+{
+    return sk_X509_num(chain);
+}
+
+void
+nc_tls_get_cert_wrap(void *chain, int idx, void **cert)
+{
+    *cert = sk_X509_value(chain, idx);
 }
 
 int

--- a/src/session_wrapper.h
+++ b/src/session_wrapper.h
@@ -66,12 +66,7 @@ struct nc_tls_ctx {
 struct nc_tls_verify_cb_data {
     struct nc_session *session;         /**< NETCONF session. */
     struct nc_server_tls_opts *opts;    /**< TLS server options. */
-    struct nc_ctn_data {
-        char *username;                 /**< Username. */
-        int matched_ctns;               /**< OR'd values of currently matched CTN types. */
-        int matched_ctn_type[6];        /**< Currently matched CTN types (order matters). */
-        int matched_ctn_count;          /**< Number of matched CTN types. */
-    } ctn_data;
+    void *chain;                        /**< Certificate chain used to verify the client cert. */
 };
 
 /**
@@ -286,6 +281,23 @@ int nc_tls_get_num_sans_wrap(void *sans);
 int nc_tls_get_san_value_type_wrap(void *sans, int idx, char **san_value, NC_TLS_CTN_MAPTYPE *san_type);
 
 #endif
+
+/**
+ * @brief Get the number of certificates in a certificate chain.
+ *
+ * @param[in] chain Certificate chain.
+ * @return Number of certificates in the chain.
+ */
+int nc_tls_get_num_certs_wrap(void *chain);
+
+/**
+ * @brief Get a certificate from a certificate chain.
+ *
+ * @param[in] chain Certificate chain.
+ * @param[in] idx Index of the certificate to get.
+ * @param[out] cert Certificate.
+ */
+void nc_tls_get_cert_wrap(void *chain, int idx, void **cert);
 
 /**
  * @brief Compare two certificates.


### PR DESCRIPTION
Before this commit cert-to-name tried to obtain the client's username solely from the client's certificate. With this commit the CA certs used to verify the client cert are also used.