### PR TITLE
session UPDATE rw socket for inactive client

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -949,7 +949,7 @@ nc_session_free(struct nc_session *session, void (*data_free)(void *))
             nc_session_client_msgs_unlock(session, __func__);
         }
 
-        if (session->status == NC_STATUS_RUNNING) {
+        if ((session->status == NC_STATUS_RUNNING) && nc_session_is_connected(session)) {
             /* receive any leftover messages */
             while (nc_read_msg_poll_io(session, 0, &msg) == 1) {
                 ly_in_free(msg, 1);


### PR DESCRIPTION
A close-session message is not sent and also the socket is not read if the netconf server terminates the connection due to an inactive client.