### PR TITLE
Fix SSH keyboard interactive auth on config change

### DIFF
--- a/modules/libnetconf2-netconf-server@2025-01-23.yang
+++ b/modules/libnetconf2-netconf-server@2025-01-23.yang
@@ -312,7 +312,6 @@ module libnetconf2-netconf-server {
       "Grouping for the SSH Keyboard interactive authentication method.";
 
     container keyboard-interactive {
-      presence "Indicates that the given client supports the SSH Keyboard Interactive authentication method.";
       description
         "Keyboard interactive SSH authentication method.";
 
@@ -322,7 +321,6 @@ module libnetconf2-netconf-server {
             the Secure Shell Protocol (SSH)";
 
       choice method {
-        mandatory true;
         description
           "Method to perform the authentication with.";
 

--- a/modules/libnetconf2-netconf-server@2025-06-02.yang
+++ b/modules/libnetconf2-netconf-server@2025-06-02.yang
@@ -31,6 +31,10 @@ module libnetconf2-netconf-server {
     prefix tlss;
   }
 
+  revision "2025-06-02" {
+    description "Removed presence from the <keyboard-interactive> container.";
+  }
+
   revision "2025-01-23" {
     description "Added a list of YANG modules skipped in the server <hello> message.";
   }

--- a/src/session_p.h
+++ b/src/session_p.h
@@ -195,7 +195,8 @@ struct nc_auth_client {
     };
 
     char *password;                             /**< Client's password */
-    enum nc_kbdint_auth_method kbdint_method;   /**< Keyboard-interactive authentication method. */
+    enum nc_kbdint_auth_method kbdint_method;   /**< Keyboard-interactive authentication method,
+                                                  *  may be extended by e.g. a union for each method when needed. */
     int none_enabled;                           /**< Implies that the client supports the none authentication method. */
 };
 

--- a/src/session_p.h
+++ b/src/session_p.h
@@ -91,6 +91,14 @@ enum nc_privkey_format {
 };
 
 /**
+ * @brief Enumeration of SSH keyboard-interactive authentication methods.
+ */
+enum nc_kbdint_auth_method {
+    NC_KBDINT_AUTH_METHOD_NONE = 0,     /**< Keyboard-interactive authentication disabled. */
+    NC_KBDINT_AUTH_METHOD_SYSTEM        /**< Keyboard-interactive authentication is left to the system (PAM, shadow, etc.). */
+};
+
+/**
  * @brief A basic certificate.
  */
 struct nc_certificate {
@@ -175,20 +183,20 @@ struct nc_auth_state {
  * @brief A server's authorized client.
  */
 struct nc_auth_client {
-    char *username;                         /**< Arbitrary username. */
+    char *username;                             /**< Arbitrary username. */
 
-    enum nc_store_type store;                    /**< Specifies how/where the client's public key is stored. */
+    enum nc_store_type store;                   /**< Specifies how/where the client's public key is stored. */
     union {
         struct {
-            struct nc_public_key *pubkeys;  /**< The client's public keys. */
-            uint16_t pubkey_count;          /**< The number of client's public keys. */
+            struct nc_public_key *pubkeys;      /**< The client's public keys. */
+            uint16_t pubkey_count;              /**< The number of client's public keys. */
         };
-        char *ts_ref;                       /**< Name of the referenced truststore key. */
+        char *ts_ref;                           /**< Name of the referenced truststore key. */
     };
 
-    char *password;                         /**< Client's password */
-    int kb_int_enabled;                     /**< Indicates that the client supports keyboard-interactive authentication. */
-    int none_enabled;                       /**< Implies that the client supports the none authentication method. */
+    char *password;                             /**< Client's password */
+    enum nc_kbdint_auth_method kbdint_method;   /**< Keyboard-interactive authentication method. */
+    int none_enabled;                           /**< Implies that the client supports the none authentication method. */
 };
 
 /**

--- a/tests/library_valgrind.supp
+++ b/tests/library_valgrind.supp
@@ -9,19 +9,11 @@
    fun:ly_ctx_new
 }
 {
-   CI:test_pam:__wrap_pam_start
+   test_pam:__wrap_pam_start_leak
    Memcheck:Leak
    match-leak-kinds: definite
    fun:malloc
    ...
-   fun:ln2_glob_test_server_thread
-   fun:ln2_glob_test_server_thread
-}
-{
-   test_pam:__wrap_pam_start
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
+   fun:__wrap_pam_start
    ...
-   fun:ln2_glob_test_server_thread
 }


### PR DESCRIPTION
Fix a bug where changing config from kbdint auth to any other type of auth requires you to still auth via kbdint. This commit also makes it possible for further extension of kbdint auth methods.