### PR TITLE
build: read packaging version form CMakeLists.txt

### DIFF
--- a/distro/scripts/make-archive.sh
+++ b/distro/scripts/make-archive.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # create archive from current source using git
 
-VERSION=$(git log --oneline -n1 --grep="^VERSION" | rev | cut -d' ' -f1 | rev)
+VERSION=$(grep \(LIBNETCONF2_M.*_VERSION CMakeLists.txt | sed 'N; N; s/[[:print:]]*[[:blank:]]\([[:digit:]]\+\)[[:print:]]/\1/g; s/\n/./g')
 
 NAMEVER=libnetconf2-$VERSION
 ARCHIVE=$NAMEVER.tar.gz


### PR DESCRIPTION
Same as CESNET/libyang#2427 for CESNET/libyang#2423.

Builds package from `CMakeLists.txt` so you can clone with `--depth=1`.
The script differs from `libyang`'s since there is a digit in the name `libnetconf2`.